### PR TITLE
[Refactor] Reorganize backend packages by domain layers

### DIFF
--- a/opicer-api/src/main/java/com/opicer/api/auth/application/JwtService.java
+++ b/opicer-api/src/main/java/com/opicer/api/auth/application/JwtService.java
@@ -1,8 +1,9 @@
-package com.opicer.api.auth;
+package com.opicer.api.auth.application;
 
+import com.opicer.api.auth.domain.AuthUserPrincipal;
 import com.opicer.api.config.AuthProperties;
-import com.opicer.api.user.AuthProvider;
-import com.opicer.api.user.UserRole;
+import com.opicer.api.user.domain.AuthProvider;
+import com.opicer.api.user.domain.UserRole;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;

--- a/opicer-api/src/main/java/com/opicer/api/auth/domain/AuthUserPrincipal.java
+++ b/opicer-api/src/main/java/com/opicer/api/auth/domain/AuthUserPrincipal.java
@@ -1,7 +1,7 @@
-package com.opicer.api.auth;
+package com.opicer.api.auth.domain;
 
-import com.opicer.api.user.AuthProvider;
-import com.opicer.api.user.UserRole;
+import com.opicer.api.user.domain.AuthProvider;
+import com.opicer.api.user.domain.UserRole;
 import java.util.UUID;
 
 public record AuthUserPrincipal(

--- a/opicer-api/src/main/java/com/opicer/api/auth/infrastructure/JwtAuthenticationFilter.java
+++ b/opicer-api/src/main/java/com/opicer/api/auth/infrastructure/JwtAuthenticationFilter.java
@@ -1,5 +1,7 @@
-package com.opicer.api.auth;
+package com.opicer.api.auth.infrastructure;
 
+import com.opicer.api.auth.application.JwtService;
+import com.opicer.api.auth.domain.AuthUserPrincipal;
 import com.opicer.api.config.AuthProperties;
 import java.io.IOException;
 import java.util.List;

--- a/opicer-api/src/main/java/com/opicer/api/auth/infrastructure/KakaoOAuth2UserService.java
+++ b/opicer-api/src/main/java/com/opicer/api/auth/infrastructure/KakaoOAuth2UserService.java
@@ -1,4 +1,4 @@
-package com.opicer.api.auth;
+package com.opicer.api.auth.infrastructure;
 
 import java.util.Collections;
 import org.slf4j.Logger;

--- a/opicer-api/src/main/java/com/opicer/api/auth/infrastructure/OAuth2LoginFailureHandler.java
+++ b/opicer-api/src/main/java/com/opicer/api/auth/infrastructure/OAuth2LoginFailureHandler.java
@@ -1,4 +1,4 @@
-package com.opicer.api.auth;
+package com.opicer.api.auth.infrastructure;
 
 import com.opicer.api.config.AuthProperties;
 import jakarta.servlet.http.HttpServletRequest;

--- a/opicer-api/src/main/java/com/opicer/api/auth/infrastructure/OAuth2LoginSuccessHandler.java
+++ b/opicer-api/src/main/java/com/opicer/api/auth/infrastructure/OAuth2LoginSuccessHandler.java
@@ -1,10 +1,12 @@
-package com.opicer.api.auth;
+package com.opicer.api.auth.infrastructure;
 
+import com.opicer.api.auth.application.JwtService;
+import com.opicer.api.auth.domain.AuthUserPrincipal;
 import com.opicer.api.config.AuthProperties;
-import com.opicer.api.user.AuthProvider;
-import com.opicer.api.user.User;
-import com.opicer.api.user.UserRole;
-import com.opicer.api.user.UserService;
+import com.opicer.api.user.application.UserService;
+import com.opicer.api.user.domain.AuthProvider;
+import com.opicer.api.user.domain.User;
+import com.opicer.api.user.domain.UserRole;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/opicer-api/src/main/java/com/opicer/api/auth/presentation/AuthController.java
+++ b/opicer-api/src/main/java/com/opicer/api/auth/presentation/AuthController.java
@@ -1,5 +1,6 @@
-package com.opicer.api.auth;
+package com.opicer.api.auth.presentation;
 
+import com.opicer.api.auth.domain.AuthUserPrincipal;
 import com.opicer.api.config.AuthProperties;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.UUID;

--- a/opicer-api/src/main/java/com/opicer/api/config/SecurityConfig.java
+++ b/opicer-api/src/main/java/com/opicer/api/config/SecurityConfig.java
@@ -10,10 +10,10 @@ import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.access.AccessDeniedHandlerImpl;
 import org.springframework.http.HttpStatus;
 
-import com.opicer.api.auth.JwtAuthenticationFilter;
-import com.opicer.api.auth.KakaoOAuth2UserService;
-import com.opicer.api.auth.OAuth2LoginFailureHandler;
-import com.opicer.api.auth.OAuth2LoginSuccessHandler;
+import com.opicer.api.auth.infrastructure.JwtAuthenticationFilter;
+import com.opicer.api.auth.infrastructure.KakaoOAuth2UserService;
+import com.opicer.api.auth.infrastructure.OAuth2LoginFailureHandler;
+import com.opicer.api.auth.infrastructure.OAuth2LoginSuccessHandler;
 
 @Configuration
 public class SecurityConfig {

--- a/opicer-api/src/main/java/com/opicer/api/health/application/HealthService.java
+++ b/opicer-api/src/main/java/com/opicer/api/health/application/HealthService.java
@@ -1,5 +1,6 @@
-package com.opicer.api.health;
+package com.opicer.api.health.application;
 
+import com.opicer.api.health.domain.HealthStatus;
 import java.time.Instant;
 import org.springframework.stereotype.Service;
 

--- a/opicer-api/src/main/java/com/opicer/api/health/domain/HealthStatus.java
+++ b/opicer-api/src/main/java/com/opicer/api/health/domain/HealthStatus.java
@@ -1,4 +1,4 @@
-package com.opicer.api.health;
+package com.opicer.api.health.domain;
 
 import java.time.Instant;
 

--- a/opicer-api/src/main/java/com/opicer/api/health/presentation/HealthController.java
+++ b/opicer-api/src/main/java/com/opicer/api/health/presentation/HealthController.java
@@ -1,5 +1,7 @@
-package com.opicer.api.health;
+package com.opicer.api.health.presentation;
 
+import com.opicer.api.health.application.HealthService;
+import com.opicer.api.health.domain.HealthStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;

--- a/opicer-api/src/main/java/com/opicer/api/user/application/UserService.java
+++ b/opicer-api/src/main/java/com/opicer/api/user/application/UserService.java
@@ -1,5 +1,9 @@
-package com.opicer.api.user;
+package com.opicer.api.user.application;
 
+import com.opicer.api.user.domain.AuthProvider;
+import com.opicer.api.user.domain.User;
+import com.opicer.api.user.domain.UserRole;
+import com.opicer.api.user.infrastructure.UserRepository;
 import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/opicer-api/src/main/java/com/opicer/api/user/domain/AuthProvider.java
+++ b/opicer-api/src/main/java/com/opicer/api/user/domain/AuthProvider.java
@@ -1,4 +1,4 @@
-package com.opicer.api.user;
+package com.opicer.api.user.domain;
 
 public enum AuthProvider {
 	KAKAO

--- a/opicer-api/src/main/java/com/opicer/api/user/domain/User.java
+++ b/opicer-api/src/main/java/com/opicer/api/user/domain/User.java
@@ -1,4 +1,4 @@
-package com.opicer.api.user;
+package com.opicer.api.user.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/opicer-api/src/main/java/com/opicer/api/user/domain/UserRole.java
+++ b/opicer-api/src/main/java/com/opicer/api/user/domain/UserRole.java
@@ -1,4 +1,4 @@
-package com.opicer.api.user;
+package com.opicer.api.user.domain;
 
 public enum UserRole {
 	USER,

--- a/opicer-api/src/main/java/com/opicer/api/user/infrastructure/UserRepository.java
+++ b/opicer-api/src/main/java/com/opicer/api/user/infrastructure/UserRepository.java
@@ -1,5 +1,7 @@
-package com.opicer.api.user;
+package com.opicer.api.user.infrastructure;
 
+import com.opicer.api.user.domain.AuthProvider;
+import com.opicer.api.user.domain.User;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/opicer-api/src/test/java/com/opicer/api/auth/application/JwtServiceTest.java
+++ b/opicer-api/src/test/java/com/opicer/api/auth/application/JwtServiceTest.java
@@ -1,8 +1,9 @@
-package com.opicer.api.auth;
+package com.opicer.api.auth.application;
 
+import com.opicer.api.auth.domain.AuthUserPrincipal;
 import com.opicer.api.config.AuthProperties;
-import com.opicer.api.user.AuthProvider;
-import com.opicer.api.user.UserRole;
+import com.opicer.api.user.domain.AuthProvider;
+import com.opicer.api.user.domain.UserRole;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 

--- a/opicer-api/src/test/java/com/opicer/api/auth/presentation/AuthControllerTest.java
+++ b/opicer-api/src/test/java/com/opicer/api/auth/presentation/AuthControllerTest.java
@@ -1,8 +1,10 @@
-package com.opicer.api.auth;
+package com.opicer.api.auth.presentation;
 
+import com.opicer.api.auth.application.JwtService;
+import com.opicer.api.auth.domain.AuthUserPrincipal;
 import com.opicer.api.config.AuthProperties;
-import com.opicer.api.user.AuthProvider;
-import com.opicer.api.user.UserRole;
+import com.opicer.api.user.domain.AuthProvider;
+import com.opicer.api.user.domain.UserRole;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
## Summary
- Reorganize backend packages into `presentation/application/domain/infrastructure` by domain
- Update imports and tests accordingly

Closes #17