### PR TITLE
[Feature] Improve home dashboard layout and daily sentence slider

### DIFF
--- a/opicer-web/src/components/home/HomeView.tsx
+++ b/opicer-web/src/components/home/HomeView.tsx
@@ -32,14 +32,11 @@ export function HomeView({
           </p>
         </div>
 
-        <div className="grid gap-8 xl:grid-cols-[1.2fr_0.8fr]">
-          <div className="space-y-8">
-            <UniversalSentencesSection />
-            <RecentActivitySection />
-          </div>
-          <div className="space-y-8">
-            <OpicScheduleSection />
-          </div>
+        <UniversalSentencesSection />
+
+        <div className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr]">
+          <RecentActivitySection />
+          <OpicScheduleSection />
         </div>
       </main>
     </div>

--- a/opicer-web/src/features/home/components/UniversalSentencesSection.tsx
+++ b/opicer-web/src/features/home/components/UniversalSentencesSection.tsx
@@ -1,7 +1,26 @@
+import { useEffect, useMemo, useState } from "react";
 import { UNIVERSAL_SENTENCES } from "@/features/home/data";
 import { SectionShell } from "@/features/home/components/SectionShell";
 
+const SLIDE_INTERVAL_MS = 5000;
+
 export function UniversalSentencesSection() {
+  const [index, setIndex] = useState(0);
+  const total = UNIVERSAL_SENTENCES.length;
+  const current = useMemo(() => UNIVERSAL_SENTENCES[index], [index]);
+
+  useEffect(() => {
+    const timer = window.setInterval(() => {
+      setIndex((prev) => (prev + 1) % total);
+    }, SLIDE_INTERVAL_MS);
+    return () => window.clearInterval(timer);
+  }, [total]);
+
+  const goTo = (next: number) => {
+    const normalized = (next + total) % total;
+    setIndex(normalized);
+  };
+
   return (
     <SectionShell
       title="Universal sentences"
@@ -12,33 +31,66 @@ export function UniversalSentencesSection() {
         </span>
       }
     >
-      <div className="grid gap-4 md:grid-cols-2">
-        {UNIVERSAL_SENTENCES.map((item) => (
-          <div
-            key={item.id}
-            className="rounded-2xl border border-black/5 bg-white/80 p-4 shadow-sm"
-          >
-            <div className="flex items-center justify-between gap-3">
-              <span className="text-sm font-semibold">{item.title}</span>
-              <span className="text-[10px] uppercase tracking-[0.2em] text-[var(--muted)]">
-                {item.situation}
-              </span>
-            </div>
-            <p className="mt-3 text-sm leading-6 text-[var(--muted)]">
-              {item.sentence}
+      <div className="flex flex-col gap-4 rounded-3xl border border-black/5 bg-white/70 p-6 shadow-sm">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-sm font-semibold text-[var(--accent-strong)]">
+              {current.title}
             </p>
-            <div className="mt-4 flex flex-wrap gap-2">
-              {item.tags.map((tag) => (
-                <span
-                  key={tag}
-                  className="rounded-full border border-[var(--accent)]/20 px-2.5 py-1 text-[10px] font-semibold text-[var(--accent-strong)]"
-                >
-                  #{tag}
-                </span>
-              ))}
-            </div>
+            <p className="mt-1 text-[10px] uppercase tracking-[0.2em] text-[var(--muted)]">
+              {current.situation}
+            </p>
           </div>
-        ))}
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => goTo(index - 1)}
+              className="flex h-9 w-9 items-center justify-center rounded-full border border-black/10 text-sm text-[var(--muted)] transition hover:border-transparent hover:bg-[var(--accent)] hover:text-white"
+              aria-label="Previous sentence"
+            >
+              ←
+            </button>
+            <button
+              type="button"
+              onClick={() => goTo(index + 1)}
+              className="flex h-9 w-9 items-center justify-center rounded-full border border-black/10 text-sm text-[var(--muted)] transition hover:border-transparent hover:bg-[var(--accent)] hover:text-white"
+              aria-label="Next sentence"
+            >
+              →
+            </button>
+          </div>
+        </div>
+
+        <p className="text-lg font-semibold leading-relaxed text-[var(--ink)]">
+          {current.sentence}
+        </p>
+
+        <div className="flex flex-wrap gap-2">
+          {current.tags.map((tag) => (
+            <span
+              key={tag}
+              className="rounded-full border border-[var(--accent)]/20 px-2.5 py-1 text-[10px] font-semibold text-[var(--accent-strong)]"
+            >
+              #{tag}
+            </span>
+          ))}
+        </div>
+
+        <div className="flex items-center gap-2 pt-2">
+          {UNIVERSAL_SENTENCES.map((item, dotIndex) => (
+            <button
+              key={item.id}
+              type="button"
+              onClick={() => goTo(dotIndex)}
+              className={`h-2.5 w-2.5 rounded-full transition ${
+                dotIndex === index
+                  ? "bg-[var(--accent)]"
+                  : "bg-[var(--accent)]/20 hover:bg-[var(--accent)]/50"
+              }`}
+              aria-label={`Go to sentence ${dotIndex + 1}`}
+            />
+          ))}
+        </div>
       </div>
     </SectionShell>
   );


### PR DESCRIPTION
## Background and Purpose
Make the home dashboard more readable by moving daily sentences to a full-width slider and aligning schedule + activity below.

## What changed
- Home layout: full-width daily sentences on top, schedule + activity below
- Daily sentences now render as auto-rotating slider with manual controls

## How to test
- Open home page and verify the slider rotates every 5s
- Use prev/next buttons and dots
- Confirm layout: sentences full-width, schedule + activity in two columns

## Risk / Rollback plan
- Low; rollback by reverting this PR

## Non-goals
- Data integration (still uses dummy data)

## Checklist
- [x] No unrelated files included
- [ ] Docs updated (not needed)

Closes #31