### PR TITLE
chore(db): switch H2 to file DB and ignore artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,5 +57,12 @@ out/
 .env
 .env.*
 
+# H2 file database
+data/
+opicer-api/data/
+*.mv.db
+*.trace.db
+*.lock.db
+
 # AI-study
 study/

--- a/opicer-api/src/main/resources/application.yaml
+++ b/opicer-api/src/main/resources/application.yaml
@@ -4,11 +4,12 @@ spring:
   profiles:
     active: default
   datasource:
-    url: jdbc:h2:mem:opicer;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    url: jdbc:h2:file:${OPICER_DB_PATH:./data/opicer};MODE=PostgreSQL;DB_CLOSE_ON_EXIT=FALSE
     driver-class-name: org.h2.Driver
     username: sa
     password:
   jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
       ddl-auto: update
     properties:

--- a/opicer-api/src/test/resources/application.yaml
+++ b/opicer-api/src/test/resources/application.yaml
@@ -1,0 +1,37 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: dummy
+            client-secret: dummy
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            scope:
+              - profile_nickname
+              - account_email
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
+opicer:
+  auth:
+    jwt-secret: test-secret-test-secret-test-secret-32bytes
+    jwt-ttl-seconds: 3600
+    cookie-name: OPICER_AUTH
+    cookie-secure: false
+    admin-allowlist: ""
+    frontend-base-url: http://localhost:3000


### PR DESCRIPTION
## Summary
- Switch H2 datasource to file mode with overridable path
- Keep tests on in-memory H2
- Ignore DB artifacts in git

## Testing
- `./gradlew test` (in `opicer-api`)

## Issue
Closes #36
