### PR TITLE
[Feature] Add MyPage history UI

### DIFF
--- a/opicer-web/src/app/mypage/page.tsx
+++ b/opicer-web/src/app/mypage/page.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { ROUTES } from "@/lib/routes";
+import { logout } from "@/lib/auth-client";
+import { useAuthState } from "@/lib/use-auth-state";
+import { LoadingScreen } from "@/components/common/LoadingScreen";
+import { MyPageView } from "@/features/mypage/components/MyPageView";
+
+export default function MyPage() {
+  const auth = useAuthState();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (auth.status === "unauthenticated") {
+      router.replace(ROUTES.login);
+    }
+  }, [auth.status, router]);
+
+  if (auth.status === "unauthenticated") return <LoadingScreen />;
+  if (auth.status === "loading") return <LoadingScreen />;
+
+  const handleLogout = async () => {
+    await logout();
+    window.location.href = ROUTES.login;
+  };
+
+  return <MyPageView userLabel={auth.user.name ?? auth.user.email ?? "사용자"} onLogout={handleLogout} />;
+}

--- a/opicer-web/src/components/common/TopNav.tsx
+++ b/opicer-web/src/components/common/TopNav.tsx
@@ -1,4 +1,8 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
+import { ROUTES } from "@/lib/routes";
 
 type NavItem = {
   title: string;
@@ -23,6 +27,31 @@ export function TopNav({
   onLogout,
   maxWidthClassName = "max-w-5xl",
 }: Props) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const handleOutside = (event: MouseEvent) => {
+      if (!menuRef.current) return;
+      if (!menuRef.current.contains(event.target as Node)) {
+        setIsMenuOpen(false);
+      }
+    };
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsMenuOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleOutside);
+    document.addEventListener("keydown", handleEscape);
+    return () => {
+      document.removeEventListener("mousedown", handleOutside);
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, []);
+
   return (
     <header
       className={`mx-auto flex w-full ${maxWidthClassName} items-center justify-between gap-6`}
@@ -57,7 +86,37 @@ export function TopNav({
 
       {userLabel && onLogout ? (
         <div className="flex shrink-0 items-center gap-3">
-          <span className="text-sm text-[var(--muted)]">{userLabel}</span>
+          <div className="relative" ref={menuRef}>
+            <button
+              type="button"
+              onClick={() => setIsMenuOpen((prev) => !prev)}
+              aria-haspopup="menu"
+              aria-expanded={isMenuOpen}
+              className="flex items-center gap-2 rounded-full border border-transparent px-3 py-1.5 text-sm text-[var(--muted)] transition hover:border-black/10 hover:bg-white"
+            >
+              <span>{userLabel}</span>
+              <span className={`text-xs transition ${isMenuOpen ? "rotate-180" : ""}`}>
+                ▾
+              </span>
+            </button>
+
+            {isMenuOpen ? (
+              <div
+                role="menu"
+                className="absolute right-0 mt-2 w-40 rounded-2xl border border-black/10 bg-white p-2 text-sm shadow-lg"
+              >
+                <Link
+                  href={ROUTES.mypage}
+                  role="menuitem"
+                  onClick={() => setIsMenuOpen(false)}
+                  className="block rounded-xl px-3 py-2 text-[var(--ink)] hover:bg-[var(--accent)]/10"
+                >
+                  마이페이지
+                </Link>
+              </div>
+            ) : null}
+          </div>
+
           <button
             onClick={onLogout}
             className="rounded-full border border-black/10 px-4 py-1.5 text-xs font-semibold text-[var(--muted)] transition hover:border-transparent hover:bg-[var(--accent)] hover:text-white"

--- a/opicer-web/src/features/mypage/components/MyPageView.tsx
+++ b/opicer-web/src/features/mypage/components/MyPageView.tsx
@@ -3,14 +3,14 @@
 import { useMemo, useState } from "react";
 import { TopNav } from "@/components/common/TopNav";
 import { PRACTICE_HISTORY } from "@/features/mypage/data";
-import type { PracticeHistory } from "@/features/mypage/types";
+import type { PracticeHistory, PracticeHistoryType } from "@/features/mypage/types";
 
 type Props = {
   userLabel?: string;
   onLogout?: () => void;
 };
 
-const SECTION_META: Record<PracticeHistory["type"], { label: string; helper: string }> = {
+const SECTION_META: Record<PracticeHistoryType, { label: string; helper: string }> = {
   topic: {
     label: "주제별 연습하기",
     helper: "선택한 주제 기반으로 연습한 기록을 확인할 수 있어요.",
@@ -20,6 +20,47 @@ const SECTION_META: Record<PracticeHistory["type"], { label: string; helper: str
     helper: "시간 제한을 고려한 실전 연습 기록을 모아 보여줘요.",
   },
 };
+
+function CategoryList({
+  activeType,
+  onChange,
+  counts,
+}: {
+  activeType: PracticeHistoryType;
+  onChange: (type: PracticeHistoryType) => void;
+  counts: Record<PracticeHistoryType, number>;
+}) {
+  return (
+    <div className="rounded-[28px] border border-black/5 bg-white/70 p-5 shadow-sm">
+      <p className="text-xs uppercase tracking-[0.2em] text-[var(--muted)]">Categories</p>
+      <div className="mt-4 space-y-2">
+        {(["topic", "mock"] as const).map((type) => {
+          const isActive = activeType === type;
+          return (
+            <button
+              key={type}
+              type="button"
+              onClick={() => onChange(type)}
+              className={`w-full rounded-2xl border px-4 py-4 text-left transition ${
+                isActive
+                  ? "border-[var(--accent)] bg-[var(--accent)]/10 shadow-md"
+                  : "border-black/10 bg-white/70 hover:border-[var(--accent)]/40"
+              }`}
+            >
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-semibold">{SECTION_META[type].label}</span>
+                <span className="rounded-full border border-black/10 px-2.5 py-1 text-[10px] font-semibold text-[var(--muted)]">
+                  {counts[type]}건
+                </span>
+              </div>
+              <p className="mt-2 text-xs text-[var(--muted)]">{SECTION_META[type].helper}</p>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
 
 function HistoryList({
   items,
@@ -73,6 +114,98 @@ function HistoryList({
   );
 }
 
+function HistoryDetail({
+  item,
+  onBack,
+}: {
+  item: PracticeHistory | null;
+  onBack: () => void;
+}) {
+  if (!item) {
+    return (
+      <div className="rounded-[28px] border border-black/5 bg-white/70 p-6 shadow-sm">
+        <p className="text-xs uppercase tracking-[0.2em] text-[var(--muted)]">Detail</p>
+        <h3 className="mt-2 text-xl font-semibold">선택된 기록 없음</h3>
+        <p className="mt-2 text-sm text-[var(--muted)]">
+          가운데 목록에서 히스토리를 선택하면 연습 상세 화면이 나타납니다.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-[28px] border border-black/5 bg-white/70 p-6 shadow-sm">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <p className="text-xs uppercase tracking-[0.2em] text-[var(--muted)]">
+              Practice Summary
+            </p>
+            <h3 className="mt-2 text-2xl font-semibold">{item.title}</h3>
+            <p className="mt-2 text-sm text-[var(--muted)]">
+              {item.topicLabel} · {item.date} · {item.durationMinutes}분
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onBack}
+            className="rounded-full border border-black/10 px-3 py-1 text-xs font-semibold text-[var(--muted)] hover:border-transparent hover:bg-[var(--accent)] hover:text-white"
+          >
+            목록으로 돌아가기
+          </button>
+        </div>
+        <p className="mt-4 text-sm text-[var(--muted)]">{item.summary}</p>
+      </section>
+
+      <section className="rounded-[28px] border border-black/5 bg-white/70 p-6 shadow-sm">
+        <div className="flex items-center justify-between">
+          <p className="text-xs uppercase tracking-[0.2em] text-[var(--muted)]">Analysis</p>
+          <span className="rounded-full border border-black/10 px-3 py-1 text-[10px] font-semibold text-[var(--muted)]">
+            준비 중
+          </span>
+        </div>
+        <h4 className="mt-2 text-xl font-semibold">연습 완료 화면</h4>
+        <p className="mt-2 text-sm text-[var(--muted)]">
+          오디오 재생, 스크립트, 수정 기능은 추후 제공됩니다.
+        </p>
+
+        <div className="mt-4 grid gap-3">
+          <div className="rounded-2xl border border-dashed border-black/10 bg-white/60 px-4 py-4 text-sm text-[var(--muted)]">
+            녹음 재생 기능 준비 중
+          </div>
+          <div className="rounded-2xl border border-dashed border-black/10 bg-white/60 px-4 py-4 text-sm text-[var(--muted)]">
+            스크립트 보기 기능 준비 중
+          </div>
+          <div className="rounded-2xl border border-dashed border-black/10 bg-white/60 px-4 py-4 text-sm text-[var(--muted)]">
+            스크립트 수정 기능 준비 중
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-[28px] border border-black/5 bg-white/70 p-6 shadow-sm">
+        <p className="text-xs uppercase tracking-[0.2em] text-[var(--muted)]">Answers</p>
+        <h4 className="mt-2 text-xl font-semibold">질문/답변 리스트</h4>
+        <div className="mt-4 space-y-3">
+          {item.answers.map((answer, index) => (
+            <div
+              key={answer.id}
+              className="rounded-2xl border border-black/10 bg-white/70 p-4"
+            >
+              <p className="text-xs uppercase tracking-[0.2em] text-[var(--muted)]">
+                Question {index + 1}
+              </p>
+              <p className="mt-2 text-sm font-semibold">{answer.question}</p>
+              <div className="mt-3 rounded-xl border border-dashed border-black/10 bg-white/60 px-3 py-2 text-xs text-[var(--muted)]">
+                녹음 미리듣기 준비 중
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
 export function MyPageView({ userLabel, onLogout }: Props) {
   const topicHistory = useMemo(
     () => PRACTICE_HISTORY.filter((item) => item.type === "topic"),
@@ -83,9 +216,15 @@ export function MyPageView({ userLabel, onLogout }: Props) {
     []
   );
 
+  const [activeType, setActiveType] = useState<PracticeHistoryType>("topic");
   const [selected, setSelected] = useState<PracticeHistory | null>(null);
 
-  const detail = selected ?? topicHistory[0] ?? mockHistory[0] ?? null;
+  const items = activeType === "topic" ? topicHistory : mockHistory;
+
+  const handleCategoryChange = (type: PracticeHistoryType) => {
+    setActiveType(type);
+    setSelected(null);
+  };
 
   return (
     <div className="min-h-screen px-6 py-10 text-[var(--ink)]">
@@ -96,115 +235,40 @@ export function MyPageView({ userLabel, onLogout }: Props) {
           <p className="text-xs uppercase tracking-[0.32em] text-[var(--muted)]">My Page</p>
           <h1 className="mt-2 text-3xl font-semibold tracking-tight">연습 히스토리</h1>
           <p className="mt-2 text-sm text-[var(--muted)]">
-            주제별/실전 연습 기록을 확인하고 분석 화면으로 바로 이동할 수 있어요.
+            주제별/실전 연습 기록을 확인하고 연습 상세 화면으로 이동할 수 있어요.
           </p>
         </section>
 
-        <div className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr]">
-          <div className="space-y-8">
-            {(["topic", "mock"] as const).map((type) => {
-              const items = type === "topic" ? topicHistory : mockHistory;
-              const meta = SECTION_META[type];
-              return (
-                <section
-                  key={type}
-                  className="rounded-[28px] border border-black/5 bg-white/70 p-6 shadow-sm"
-                >
-                  <div className="flex flex-wrap items-end justify-between gap-3">
-                    <div>
-                      <p className="text-xs uppercase tracking-[0.2em] text-[var(--muted)]">
-                        {meta.label}
-                      </p>
-                      <h2 className="mt-1 text-2xl font-semibold">{meta.label}</h2>
-                      <p className="mt-2 text-sm text-[var(--muted)]">{meta.helper}</p>
-                    </div>
-                    <span className="text-xs text-[var(--muted)]">{items.length}건</span>
-                  </div>
-
-                  <div className="mt-6">
-                    <HistoryList
-                      items={items}
-                      selectedId={detail?.id}
-                      onSelect={setSelected}
-                    />
-                  </div>
-                </section>
-              );
-            })}
-          </div>
-
+        <div className="grid gap-8 lg:grid-cols-[220px_minmax(0,1fr)_minmax(0,420px)]">
           <aside className="space-y-6">
-            <section className="rounded-[28px] border border-black/5 bg-white/70 p-6 shadow-sm">
-              <p className="text-xs uppercase tracking-[0.2em] text-[var(--muted)]">
-                History Detail
-              </p>
-              <h2 className="mt-2 text-2xl font-semibold">
-                {detail ? detail.title : "선택된 기록 없음"}
-              </h2>
-              {detail ? (
-                <p className="mt-2 text-sm text-[var(--muted)]">
-                  {detail.topicLabel} · {detail.date} · {detail.durationMinutes}분
-                </p>
-              ) : (
-                <p className="mt-2 text-sm text-[var(--muted)]">
-                  좌측에서 기록을 선택하면 분석 화면이 나타납니다.
-                </p>
-              )}
-            </section>
+            <CategoryList
+              activeType={activeType}
+              onChange={handleCategoryChange}
+              counts={{ topic: topicHistory.length, mock: mockHistory.length }}
+            />
+          </aside>
 
-            <section className="rounded-[28px] border border-black/5 bg-white/70 p-6 shadow-sm">
-              <div className="flex items-center justify-between">
+          <section className="rounded-[28px] border border-black/5 bg-white/70 p-6 shadow-sm">
+            <div className="flex items-end justify-between gap-4">
+              <div>
                 <p className="text-xs uppercase tracking-[0.2em] text-[var(--muted)]">
-                  Analysis
+                  {SECTION_META[activeType].label}
                 </p>
-                <span className="rounded-full border border-black/10 px-3 py-1 text-[10px] font-semibold text-[var(--muted)]">
-                  준비 중
-                </span>
+                <h2 className="mt-1 text-2xl font-semibold">{SECTION_META[activeType].label}</h2>
+                <p className="mt-2 text-sm text-[var(--muted)]">
+                  {SECTION_META[activeType].helper}
+                </p>
               </div>
-              <h3 className="mt-2 text-xl font-semibold">연습 완료 화면</h3>
-              <p className="mt-2 text-sm text-[var(--muted)]">
-                오디오 재생, 스크립트, 수정 기능은 추후 제공됩니다.
-              </p>
+              <span className="text-xs text-[var(--muted)]">{items.length}건</span>
+            </div>
 
-              <div className="mt-4 grid gap-3">
-                <div className="rounded-2xl border border-dashed border-black/10 bg-white/60 px-4 py-4 text-sm text-[var(--muted)]">
-                  녹음 재생 기능 준비 중
-                </div>
-                <div className="rounded-2xl border border-dashed border-black/10 bg-white/60 px-4 py-4 text-sm text-[var(--muted)]">
-                  스크립트 보기 기능 준비 중
-                </div>
-                <div className="rounded-2xl border border-dashed border-black/10 bg-white/60 px-4 py-4 text-sm text-[var(--muted)]">
-                  스크립트 수정 기능 준비 중
-                </div>
-              </div>
-            </section>
+            <div className="mt-6">
+              <HistoryList items={items} selectedId={selected?.id} onSelect={setSelected} />
+            </div>
+          </section>
 
-            <section className="rounded-[28px] border border-black/5 bg-white/70 p-6 shadow-sm">
-              <p className="text-xs uppercase tracking-[0.2em] text-[var(--muted)]">Answers</p>
-              <h3 className="mt-2 text-xl font-semibold">질문/답변 리스트</h3>
-              <div className="mt-4 space-y-3">
-                {detail?.answers?.length ? (
-                  detail.answers.map((answer, index) => (
-                    <div
-                      key={answer.id}
-                      className="rounded-2xl border border-black/10 bg-white/70 p-4"
-                    >
-                      <p className="text-xs uppercase tracking-[0.2em] text-[var(--muted)]">
-                        Question {index + 1}
-                      </p>
-                      <p className="mt-2 text-sm font-semibold">{answer.question}</p>
-                      <div className="mt-3 rounded-xl border border-dashed border-black/10 bg-white/60 px-3 py-2 text-xs text-[var(--muted)]">
-                        녹음 미리듣기 준비 중
-                      </div>
-                    </div>
-                  ))
-                ) : (
-                  <p className="text-sm text-[var(--muted)]">
-                    선택된 기록이 없습니다.
-                  </p>
-                )}
-              </div>
-            </section>
+          <aside>
+            <HistoryDetail item={selected} onBack={() => setSelected(null)} />
           </aside>
         </div>
       </div>

--- a/opicer-web/src/features/mypage/components/MyPageView.tsx
+++ b/opicer-web/src/features/mypage/components/MyPageView.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { TopNav } from "@/components/common/TopNav";
+import { PRACTICE_HISTORY } from "@/features/mypage/data";
+import type { PracticeHistory } from "@/features/mypage/types";
+
+type Props = {
+  userLabel?: string;
+  onLogout?: () => void;
+};
+
+const SECTION_META: Record<PracticeHistory["type"], { label: string; helper: string }> = {
+  topic: {
+    label: "주제별 연습하기",
+    helper: "선택한 주제 기반으로 연습한 기록을 확인할 수 있어요.",
+  },
+  mock: {
+    label: "실전 연습하기",
+    helper: "시간 제한을 고려한 실전 연습 기록을 모아 보여줘요.",
+  },
+};
+
+function HistoryList({
+  items,
+  selectedId,
+  onSelect,
+}: {
+  items: PracticeHistory[];
+  selectedId?: string | null;
+  onSelect: (item: PracticeHistory) => void;
+}) {
+  if (items.length === 0) {
+    return (
+      <div className="rounded-2xl border border-dashed border-black/10 bg-white/60 px-4 py-6 text-sm text-[var(--muted)]">
+        기록이 아직 없습니다.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {items.map((item) => {
+        const isActive = item.id === selectedId;
+        return (
+          <button
+            key={item.id}
+            type="button"
+            onClick={() => onSelect(item)}
+            className={`w-full rounded-2xl border px-4 py-4 text-left transition ${
+              isActive
+                ? "border-[var(--accent)] bg-[var(--accent)]/10 shadow-md"
+                : "border-black/10 bg-white/70 hover:border-[var(--accent)]/40"
+            }`}
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <p className="text-sm font-semibold text-[var(--ink)]">{item.title}</p>
+                <p className="mt-1 text-xs text-[var(--muted)]">{item.topicLabel}</p>
+              </div>
+              <span className="rounded-full border border-black/10 px-2.5 py-1 text-[10px] font-semibold text-[var(--muted)]">
+                {item.durationMinutes}분
+              </span>
+            </div>
+            <div className="mt-3 flex items-center justify-between text-xs text-[var(--muted)]">
+              <span>{item.date}</span>
+              <span>히스토리 보기 →</span>
+            </div>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export function MyPageView({ userLabel, onLogout }: Props) {
+  const topicHistory = useMemo(
+    () => PRACTICE_HISTORY.filter((item) => item.type === "topic"),
+    []
+  );
+  const mockHistory = useMemo(
+    () => PRACTICE_HISTORY.filter((item) => item.type === "mock"),
+    []
+  );
+
+  const [selected, setSelected] = useState<PracticeHistory | null>(null);
+
+  const detail = selected ?? topicHistory[0] ?? mockHistory[0] ?? null;
+
+  return (
+    <div className="min-h-screen px-6 py-10 text-[var(--ink)]">
+      <div className="mx-auto flex max-w-6xl flex-col gap-8">
+        <TopNav userLabel={userLabel} onLogout={onLogout} maxWidthClassName="max-w-6xl" />
+
+        <section className="rounded-[32px] border border-black/5 bg-white/70 p-8 shadow-sm">
+          <p className="text-xs uppercase tracking-[0.32em] text-[var(--muted)]">My Page</p>
+          <h1 className="mt-2 text-3xl font-semibold tracking-tight">연습 히스토리</h1>
+          <p className="mt-2 text-sm text-[var(--muted)]">
+            주제별/실전 연습 기록을 확인하고 분석 화면으로 바로 이동할 수 있어요.
+          </p>
+        </section>
+
+        <div className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr]">
+          <div className="space-y-8">
+            {(["topic", "mock"] as const).map((type) => {
+              const items = type === "topic" ? topicHistory : mockHistory;
+              const meta = SECTION_META[type];
+              return (
+                <section
+                  key={type}
+                  className="rounded-[28px] border border-black/5 bg-white/70 p-6 shadow-sm"
+                >
+                  <div className="flex flex-wrap items-end justify-between gap-3">
+                    <div>
+                      <p className="text-xs uppercase tracking-[0.2em] text-[var(--muted)]">
+                        {meta.label}
+                      </p>
+                      <h2 className="mt-1 text-2xl font-semibold">{meta.label}</h2>
+                      <p className="mt-2 text-sm text-[var(--muted)]">{meta.helper}</p>
+                    </div>
+                    <span className="text-xs text-[var(--muted)]">{items.length}건</span>
+                  </div>
+
+                  <div className="mt-6">
+                    <HistoryList
+                      items={items}
+                      selectedId={detail?.id}
+                      onSelect={setSelected}
+                    />
+                  </div>
+                </section>
+              );
+            })}
+          </div>
+
+          <aside className="space-y-6">
+            <section className="rounded-[28px] border border-black/5 bg-white/70 p-6 shadow-sm">
+              <p className="text-xs uppercase tracking-[0.2em] text-[var(--muted)]">
+                History Detail
+              </p>
+              <h2 className="mt-2 text-2xl font-semibold">
+                {detail ? detail.title : "선택된 기록 없음"}
+              </h2>
+              {detail ? (
+                <p className="mt-2 text-sm text-[var(--muted)]">
+                  {detail.topicLabel} · {detail.date} · {detail.durationMinutes}분
+                </p>
+              ) : (
+                <p className="mt-2 text-sm text-[var(--muted)]">
+                  좌측에서 기록을 선택하면 분석 화면이 나타납니다.
+                </p>
+              )}
+            </section>
+
+            <section className="rounded-[28px] border border-black/5 bg-white/70 p-6 shadow-sm">
+              <div className="flex items-center justify-between">
+                <p className="text-xs uppercase tracking-[0.2em] text-[var(--muted)]">
+                  Analysis
+                </p>
+                <span className="rounded-full border border-black/10 px-3 py-1 text-[10px] font-semibold text-[var(--muted)]">
+                  준비 중
+                </span>
+              </div>
+              <h3 className="mt-2 text-xl font-semibold">연습 완료 화면</h3>
+              <p className="mt-2 text-sm text-[var(--muted)]">
+                오디오 재생, 스크립트, 수정 기능은 추후 제공됩니다.
+              </p>
+
+              <div className="mt-4 grid gap-3">
+                <div className="rounded-2xl border border-dashed border-black/10 bg-white/60 px-4 py-4 text-sm text-[var(--muted)]">
+                  녹음 재생 기능 준비 중
+                </div>
+                <div className="rounded-2xl border border-dashed border-black/10 bg-white/60 px-4 py-4 text-sm text-[var(--muted)]">
+                  스크립트 보기 기능 준비 중
+                </div>
+                <div className="rounded-2xl border border-dashed border-black/10 bg-white/60 px-4 py-4 text-sm text-[var(--muted)]">
+                  스크립트 수정 기능 준비 중
+                </div>
+              </div>
+            </section>
+
+            <section className="rounded-[28px] border border-black/5 bg-white/70 p-6 shadow-sm">
+              <p className="text-xs uppercase tracking-[0.2em] text-[var(--muted)]">Answers</p>
+              <h3 className="mt-2 text-xl font-semibold">질문/답변 리스트</h3>
+              <div className="mt-4 space-y-3">
+                {detail?.answers?.length ? (
+                  detail.answers.map((answer, index) => (
+                    <div
+                      key={answer.id}
+                      className="rounded-2xl border border-black/10 bg-white/70 p-4"
+                    >
+                      <p className="text-xs uppercase tracking-[0.2em] text-[var(--muted)]">
+                        Question {index + 1}
+                      </p>
+                      <p className="mt-2 text-sm font-semibold">{answer.question}</p>
+                      <div className="mt-3 rounded-xl border border-dashed border-black/10 bg-white/60 px-3 py-2 text-xs text-[var(--muted)]">
+                        녹음 미리듣기 준비 중
+                      </div>
+                    </div>
+                  ))
+                ) : (
+                  <p className="text-sm text-[var(--muted)]">
+                    선택된 기록이 없습니다.
+                  </p>
+                )}
+              </div>
+            </section>
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/opicer-web/src/features/mypage/components/MyPageView.tsx
+++ b/opicer-web/src/features/mypage/components/MyPageView.tsx
@@ -239,7 +239,7 @@ export function MyPageView({ userLabel, onLogout }: Props) {
           </p>
         </section>
 
-        <div className="grid gap-8 lg:grid-cols-[220px_minmax(0,1fr)_minmax(0,420px)]">
+        <div className="grid gap-8 lg:grid-cols-[220px_minmax(0,1fr)]">
           <aside className="space-y-6">
             <CategoryList
               activeType={activeType}
@@ -248,28 +248,30 @@ export function MyPageView({ userLabel, onLogout }: Props) {
             />
           </aside>
 
-          <section className="rounded-[28px] border border-black/5 bg-white/70 p-6 shadow-sm">
-            <div className="flex items-end justify-between gap-4">
-              <div>
-                <p className="text-xs uppercase tracking-[0.2em] text-[var(--muted)]">
-                  {SECTION_META[activeType].label}
-                </p>
-                <h2 className="mt-1 text-2xl font-semibold">{SECTION_META[activeType].label}</h2>
-                <p className="mt-2 text-sm text-[var(--muted)]">
-                  {SECTION_META[activeType].helper}
-                </p>
-              </div>
-              <span className="text-xs text-[var(--muted)]">{items.length}건</span>
-            </div>
-
-            <div className="mt-6">
-              <HistoryList items={items} selectedId={selected?.id} onSelect={setSelected} />
-            </div>
-          </section>
-
-          <aside>
+          {selected ? (
             <HistoryDetail item={selected} onBack={() => setSelected(null)} />
-          </aside>
+          ) : (
+            <section className="rounded-[28px] border border-black/5 bg-white/70 p-6 shadow-sm">
+              <div className="flex items-end justify-between gap-4">
+                <div>
+                  <p className="text-xs uppercase tracking-[0.2em] text-[var(--muted)]">
+                    {SECTION_META[activeType].label}
+                  </p>
+                  <h2 className="mt-1 text-2xl font-semibold">
+                    {SECTION_META[activeType].label}
+                  </h2>
+                  <p className="mt-2 text-sm text-[var(--muted)]">
+                    {SECTION_META[activeType].helper}
+                  </p>
+                </div>
+                <span className="text-xs text-[var(--muted)]">{items.length}건</span>
+              </div>
+
+              <div className="mt-6">
+                <HistoryList items={items} selectedId={selected?.id} onSelect={setSelected} />
+              </div>
+            </section>
+          )}
         </div>
       </div>
     </div>

--- a/opicer-web/src/features/mypage/data.ts
+++ b/opicer-web/src/features/mypage/data.ts
@@ -1,0 +1,74 @@
+import type { PracticeHistory } from "@/features/mypage/types";
+
+export const PRACTICE_HISTORY: PracticeHistory[] = [
+  {
+    id: "topic-1",
+    type: "topic",
+    title: "자기소개 & 일상 루틴",
+    topicLabel: "일상/자기소개",
+    date: "2026-02-24 21:40",
+    durationMinutes: 18,
+    summary: "가벼운 워밍업 질문 중심으로 답변 구조 점검",
+    answers: [
+      { id: "a1", question: "Tell me about yourself." },
+      { id: "a2", question: "Describe a typical weekday for you." },
+      { id: "a3", question: "What do you do after work or school?" },
+    ],
+  },
+  {
+    id: "topic-2",
+    type: "topic",
+    title: "여행 경험",
+    topicLabel: "여행",
+    date: "2026-02-23 22:10",
+    durationMinutes: 22,
+    summary: "경험 묘사, 감정 표현, 비교 표현 연습",
+    answers: [
+      { id: "b1", question: "Talk about your most memorable trip." },
+      { id: "b2", question: "Describe the place you visited." },
+      { id: "b3", question: "Would you visit again? Why?" },
+    ],
+  },
+  {
+    id: "topic-3",
+    type: "topic",
+    title: "취미/여가 활동",
+    topicLabel: "취미",
+    date: "2026-02-21 20:35",
+    durationMinutes: 20,
+    summary: "선호도 비교와 이유 설명 흐름 점검",
+    answers: [
+      { id: "c1", question: "What do you like to do in your free time?" },
+      { id: "c2", question: "How did you start this hobby?" },
+      { id: "c3", question: "Tell me about a recent hobby experience." },
+    ],
+  },
+  {
+    id: "mock-1",
+    type: "mock",
+    title: "실전 연습 #01",
+    topicLabel: "혼합 주제",
+    date: "2026-02-24 23:05",
+    durationMinutes: 40,
+    summary: "총 12문항, 시간 압박 구간 대응 점검",
+    answers: [
+      { id: "m1", question: "Tell me about your neighborhood." },
+      { id: "m2", question: "Describe a memorable restaurant visit." },
+      { id: "m3", question: "Explain a recent problem you solved." },
+    ],
+  },
+  {
+    id: "mock-2",
+    type: "mock",
+    title: "실전 연습 #02",
+    topicLabel: "혼합 주제",
+    date: "2026-02-19 21:15",
+    durationMinutes: 38,
+    summary: "스토리텔링 연결성 개선 목표",
+    answers: [
+      { id: "m4", question: "Describe a hobby you tried recently." },
+      { id: "m5", question: "Talk about a trip you took with friends." },
+      { id: "m6", question: "Tell me about a daily routine you enjoy." },
+    ],
+  },
+];

--- a/opicer-web/src/features/mypage/types.ts
+++ b/opicer-web/src/features/mypage/types.ts
@@ -1,0 +1,18 @@
+export type PracticeHistoryType = "topic" | "mock";
+
+export type PracticeAnswer = {
+  id: string;
+  question: string;
+  audioUrl?: string;
+};
+
+export type PracticeHistory = {
+  id: string;
+  type: PracticeHistoryType;
+  title: string;
+  topicLabel: string;
+  date: string;
+  durationMinutes: number;
+  summary: string;
+  answers: PracticeAnswer[];
+};

--- a/opicer-web/src/lib/routes.ts
+++ b/opicer-web/src/lib/routes.ts
@@ -2,6 +2,7 @@ export const ROUTES = {
   home: "/",
   login: "/login",
   admin: "/admin",
+  mypage: "/mypage",
   practice: "/practice",
   practiceSession: (topicId: string) => `/practice/${topicId}` as const,
   auth: {

--- a/plan-mypage.md
+++ b/plan-mypage.md
@@ -5,14 +5,16 @@
 - References (Opicer.md, issues, decisions): 사용자 지시사항(2026-02-25)
 
 ## Objective
-- `/mypage` 화면에서 주제별/실전 연습 히스토리를 섹션으로 관리하고, 아이템 클릭 시 같은 페이지 내 분석 패널로 전환되도록 한다.
+- `/mypage` 화면에서 좌측 카테고리(주제별/실전)와 히스토리 리스트를 분리하고, 아이템 클릭 시 같은 페이지 내 연습 상세 화면으로 전환되도록 한다.
 
 ## Scope
 - In (MVP):
   - TopNav 사용자 이름 클릭 시 드롭다운 → 마이페이지 이동
   - `/mypage` 페이지 생성
   - 더미 히스토리 데이터로 UI 구성
-  - 히스토리 클릭 시 같은 페이지 내 분석 패널 표시(오디오/스크립트/수정은 placeholder)
+  - 좌측 카테고리 리스트(주제별/실전) 및 기본 선택(주제별)
+  - 히스토리 클릭 시 같은 페이지 내 연습 상세 화면 표시(오디오/스크립트/수정은 placeholder)
+  - 상세 화면에서 히스토리 리스트로 돌아가는 동선 제공
 - Out (v2+):
   - 실제 데이터 연동(백엔드)
   - 오디오 재생, 스크립트 보기/수정 기능
@@ -23,8 +25,10 @@
 
 ## Requirements (Acceptance Criteria)
 - [ ] TopNav 사용자 이름 클릭 → 드롭다운에 마이페이지 링크 표시
-- [ ] `/mypage` 페이지에서 “주제별 연습하기” / “실전 연습하기” 섹션이 구분되어 표시됨
-- [ ] 히스토리 아이템 클릭 시 같은 페이지 내 분석 패널로 전환됨
+- [ ] `/mypage` 좌측 카테고리(주제별/실전) 리스트 표시, 기본은 주제별 선택
+- [ ] 선택된 카테고리에 해당하는 히스토리 리스트 표시
+- [ ] 히스토리 아이템 클릭 시 같은 페이지 내 연습 상세 화면 표시
+- [ ] 상세 화면에서 리스트로 돌아가는 버튼 제공
 - [ ] 분석 패널은 UI 구조만 제공(오디오/스크립트/수정 기능은 비활성 또는 placeholder)
 
 ## Scenarios (Fixed with Expected Outputs)
@@ -33,23 +37,27 @@
   - Expected: 드롭다운에 “마이페이지” 항목 표시, 클릭 시 `/mypage` 이동
 - S2: `/mypage` 진입
   - Input: `/mypage` 접속
-  - Expected: 주제별/실전 섹션 + 더미 히스토리 리스트 표시
-- S3: 히스토리 선택
+  - Expected: 좌측 카테고리 리스트 + 선택된 카테고리 히스토리 리스트 표시
+- S3: 카테고리 전환
+  - Input: 실전 연습하기 클릭
+  - Expected: 실전 히스토리 리스트로 변경
+- S4: 히스토리 선택
   - Input: 히스토리 아이템 클릭
-  - Expected: 동일 페이지 내 분석 패널 표시
+  - Expected: 동일 페이지 내 연습 상세 화면 표시, 리스트는 유지
 
 ## Edge Cases (Deterministic Handling)
 - E1: 히스토리 없음
   - Rule: “기록이 없습니다” 메시지 표시
-- E2: 분석 패널 선택 해제
+- E2: 상세 화면 복귀
   - Rule: 뒤로가기/닫기 버튼으로 리스트 화면 복귀
 
 ## Design
 - UI
   - TopNav 드롭다운 (사용자 이름 클릭)
-  - `/mypage` 화면: 2단 레이아웃
-    - 좌측: 히스토리 섹션 (주제별/실전)
-    - 우측: 선택된 히스토리 분석 패널
+  - `/mypage` 화면: 2~3단 레이아웃
+    - 좌측: 카테고리 리스트(주제별/실전)
+    - 중앙: 선택된 카테고리 히스토리 리스트
+    - 우측: 선택된 히스토리 상세(연습 화면 스타일)
 - Data model (UI only)
   - HistoryItem: id, type(topic|mock), title, date, duration, topic, summary
 
@@ -57,9 +65,9 @@
 - [ ] 1. TopNav 드롭다운에 “마이페이지” 링크 추가
 - [ ] 2. `/mypage` 페이지 및 기본 레이아웃 추가
 - [ ] 3. 더미 히스토리 데이터 및 리스트/패널 전환 로직 구현
-- [ ] 4. Empty state 및 분석 패널 placeholder 추가
+- [ ] 4. 상세 화면 및 복귀 버튼 placeholder 추가
 
 ## Verification (Definition of Done)
 - Automated: N/A (UI-only)
-- Manual: 시나리오 S1~S3 확인
+- Manual: 시나리오 S1~S4 확인
 - Documentation: `plan-mypage.md` 유지

--- a/plan-mypage.md
+++ b/plan-mypage.md
@@ -1,0 +1,65 @@
+# Plan: MyPage UI
+
+## Context
+- Problem statement: 마이페이지 UI/흐름 추가 (드롭다운 → 마이페이지, 히스토리 섹션 분리, 상세 패널 전환)
+- References (Opicer.md, issues, decisions): 사용자 지시사항(2026-02-25)
+
+## Objective
+- `/mypage` 화면에서 주제별/실전 연습 히스토리를 섹션으로 관리하고, 아이템 클릭 시 같은 페이지 내 분석 패널로 전환되도록 한다.
+
+## Scope
+- In (MVP):
+  - TopNav 사용자 이름 클릭 시 드롭다운 → 마이페이지 이동
+  - `/mypage` 페이지 생성
+  - 더미 히스토리 데이터로 UI 구성
+  - 히스토리 클릭 시 같은 페이지 내 분석 패널 표시(오디오/스크립트/수정은 placeholder)
+- Out (v2+):
+  - 실제 데이터 연동(백엔드)
+  - 오디오 재생, 스크립트 보기/수정 기능
+  - 히스토리 필터/검색
+
+## API Contracts (Frozen for MVP)
+- 없음 (UI-only, 더미 데이터)
+
+## Requirements (Acceptance Criteria)
+- [ ] TopNav 사용자 이름 클릭 → 드롭다운에 마이페이지 링크 표시
+- [ ] `/mypage` 페이지에서 “주제별 연습하기” / “실전 연습하기” 섹션이 구분되어 표시됨
+- [ ] 히스토리 아이템 클릭 시 같은 페이지 내 분석 패널로 전환됨
+- [ ] 분석 패널은 UI 구조만 제공(오디오/스크립트/수정 기능은 비활성 또는 placeholder)
+
+## Scenarios (Fixed with Expected Outputs)
+- S1: 로그인 상태에서 사용자 이름 클릭
+  - Input: TopNav 사용자 이름 클릭
+  - Expected: 드롭다운에 “마이페이지” 항목 표시, 클릭 시 `/mypage` 이동
+- S2: `/mypage` 진입
+  - Input: `/mypage` 접속
+  - Expected: 주제별/실전 섹션 + 더미 히스토리 리스트 표시
+- S3: 히스토리 선택
+  - Input: 히스토리 아이템 클릭
+  - Expected: 동일 페이지 내 분석 패널 표시
+
+## Edge Cases (Deterministic Handling)
+- E1: 히스토리 없음
+  - Rule: “기록이 없습니다” 메시지 표시
+- E2: 분석 패널 선택 해제
+  - Rule: 뒤로가기/닫기 버튼으로 리스트 화면 복귀
+
+## Design
+- UI
+  - TopNav 드롭다운 (사용자 이름 클릭)
+  - `/mypage` 화면: 2단 레이아웃
+    - 좌측: 히스토리 섹션 (주제별/실전)
+    - 우측: 선택된 히스토리 분석 패널
+- Data model (UI only)
+  - HistoryItem: id, type(topic|mock), title, date, duration, topic, summary
+
+## Tasks
+- [ ] 1. TopNav 드롭다운에 “마이페이지” 링크 추가
+- [ ] 2. `/mypage` 페이지 및 기본 레이아웃 추가
+- [ ] 3. 더미 히스토리 데이터 및 리스트/패널 전환 로직 구현
+- [ ] 4. Empty state 및 분석 패널 placeholder 추가
+
+## Verification (Definition of Done)
+- Automated: N/A (UI-only)
+- Manual: 시나리오 S1~S3 확인
+- Documentation: `plan-mypage.md` 유지


### PR DESCRIPTION
## Background and Purpose
마이페이지 UI를 추가해 히스토리를 주제별/실전 연습 카테고리로 관리하고, TopNav 사용자 이름 클릭 시 마이페이지로 이동하는 드롭다운을 제공한다.

## What changed
- TopNav 사용자 이름 드롭다운 → 마이페이지 링크 추가
- `/mypage` 페이지 및 히스토리 UI 추가
- 좌측 카테고리(주제별/실전) + 히스토리 리스트 + 상세 패널 3단 레이아웃
- 히스토리 클릭 시 동일 페이지 내 상세 패널 표시, “목록으로 돌아가기” 제공
- 더미 히스토리 데이터/분석 패널(placeholder) 구성
- 라우트 `ROUTES.mypage` 추가

## How to test
1. 로그인 후 TopNav 사용자 이름 클릭 → 드롭다운에 “마이페이지” 확인
2. “마이페이지” 클릭 → `/mypage` 이동
3. 좌측 카테고리 변경 → 히스토리 리스트 변경
4. 히스토리 선택 → 우측 상세 패널 표시, “목록으로 돌아가기” 동작

## Risk / Rollback
- Risk: Low (UI-only)
- Rollback: PR revert

## Checklist
- [ ] Tests passing (UI-only)
- [x] No unrelated files included
- [x] Docs updated if needed

Closes #50