### PR TITLE
[Feature] Integrate AI for topic practice

### DIFF
--- a/opicer-api/src/main/java/com/opicer/api/config/AiProperties.java
+++ b/opicer-api/src/main/java/com/opicer/api/config/AiProperties.java
@@ -1,0 +1,26 @@
+package com.opicer.api.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "opicer.ai")
+public class AiProperties {
+
+	private String openaiApiKey = "";
+	private String anthropicApiKey = "";
+
+	public String getOpenaiApiKey() {
+		return openaiApiKey;
+	}
+
+	public void setOpenaiApiKey(String openaiApiKey) {
+		this.openaiApiKey = openaiApiKey;
+	}
+
+	public String getAnthropicApiKey() {
+		return anthropicApiKey;
+	}
+
+	public void setAnthropicApiKey(String anthropicApiKey) {
+		this.anthropicApiKey = anthropicApiKey;
+	}
+}

--- a/opicer-api/src/main/java/com/opicer/api/practice/application/PracticeAiService.java
+++ b/opicer-api/src/main/java/com/opicer/api/practice/application/PracticeAiService.java
@@ -1,0 +1,161 @@
+package com.opicer.api.practice.application;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.opicer.api.config.AiProperties;
+import com.opicer.api.prompt.application.PromptVersionService;
+import com.opicer.api.prompt.domain.PromptUseCase;
+import com.opicer.api.prompt.domain.PromptVersion;
+import com.opicer.api.shared.error.ApiException;
+import com.opicer.api.shared.error.ErrorCode;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+public class PracticeAiService {
+
+	private static final Logger log = LoggerFactory.getLogger(PracticeAiService.class);
+
+	private static final String DEFAULT_FEEDBACK_TEMPLATE =
+		"You are an OPIC speaking coach. Analyze this student's response in Korean.\n" +
+		"Question: {questionText}\n" +
+		"Student's answer: {transcript}\n" +
+		"Provide analysis: 1.내용구성 2.표현력 3.레벨평가(NL/IL/IM/IH/AL) 4.개선포인트 top3";
+
+	private static final String DEFAULT_SCRIPT_IMPROVEMENT_TEMPLATE =
+		"You are an OPIC speaking coach. Improve this answer, preserving personal content.\n" +
+		"Question: {questionText}\n" +
+		"Original: {transcript}\n" +
+		"Return ONLY the improved script. Target IL~IM level.";
+
+	private final AiProperties aiProperties;
+	private final PromptVersionService promptVersionService;
+	private final RestClient restClient;
+
+	public PracticeAiService(AiProperties aiProperties, PromptVersionService promptVersionService) {
+		this.aiProperties = aiProperties;
+		this.promptVersionService = promptVersionService;
+		this.restClient = RestClient.create();
+	}
+
+	public String transcribe(MultipartFile audio, String questionText) {
+		String apiKey = aiProperties.getOpenaiApiKey();
+		if (apiKey == null || apiKey.isBlank()) {
+			throw new ApiException(ErrorCode.AI_NOT_CONFIGURED);
+		}
+		try {
+			MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+			body.add("file", new MultipartInputStreamFileResource(audio.getInputStream(), "audio.webm"));
+			body.add("model", "whisper-1");
+			body.add("response_format", "text");
+
+			return restClient.post()
+				.uri("https://api.openai.com/v1/audio/transcriptions")
+				.header("Authorization", "Bearer " + apiKey)
+				.contentType(MediaType.MULTIPART_FORM_DATA)
+				.body(body)
+				.retrieve()
+				.body(String.class);
+		} catch (RestClientException e) {
+			log.error("[Whisper] API call failed: {}", e.getMessage(), e);
+			throw new ApiException(ErrorCode.AI_TRANSCRIPTION_FAILED, e.getMessage());
+		} catch (Exception e) {
+			log.error("[Whisper] Unexpected error: {}", e.getMessage(), e);
+			throw new ApiException(ErrorCode.AI_TRANSCRIPTION_FAILED, e.getMessage());
+		}
+	}
+
+	public String analyze(String questionText, String transcript) {
+		String apiKey = aiProperties.getAnthropicApiKey();
+		if (apiKey == null || apiKey.isBlank()) {
+			throw new ApiException(ErrorCode.AI_NOT_CONFIGURED);
+		}
+		String template = promptVersionService.findActiveByUseCase(PromptUseCase.FEEDBACK)
+			.map(PromptVersion::getTemplate)
+			.orElse(DEFAULT_FEEDBACK_TEMPLATE);
+		String prompt = template
+			.replace("{questionText}", questionText)
+			.replace("{transcript}", transcript);
+		return callClaude(apiKey, prompt);
+	}
+
+	public String improve(String questionText, String transcript) {
+		String apiKey = aiProperties.getAnthropicApiKey();
+		if (apiKey == null || apiKey.isBlank()) {
+			throw new ApiException(ErrorCode.AI_NOT_CONFIGURED);
+		}
+		String template = promptVersionService.findActiveByUseCase(PromptUseCase.SCRIPT_IMPROVEMENT)
+			.map(PromptVersion::getTemplate)
+			.orElse(DEFAULT_SCRIPT_IMPROVEMENT_TEMPLATE);
+		String prompt = template
+			.replace("{questionText}", questionText)
+			.replace("{transcript}", transcript);
+		return callClaude(apiKey, prompt);
+	}
+
+	private String callClaude(String apiKey, String prompt) {
+		try {
+			Map<String, Object> req = Map.of(
+				"model", "claude-opus-4-6",
+				"max_tokens", 1024,
+				"messages", List.of(Map.of("role", "user", "content", prompt))
+			);
+			ClaudeResponse response = restClient.post()
+				.uri("https://api.anthropic.com/v1/messages")
+				.header("x-api-key", apiKey)
+				.header("anthropic-version", "2023-06-01")
+				.contentType(MediaType.APPLICATION_JSON)
+				.body(req)
+				.retrieve()
+				.body(ClaudeResponse.class);
+			if (response == null || response.content() == null || response.content().isEmpty()) {
+				throw new ApiException(ErrorCode.AI_ANALYSIS_FAILED, "Empty response from AI");
+			}
+			return response.content().get(0).text();
+		} catch (ApiException e) {
+			throw e;
+		} catch (RestClientException e) {
+			log.error("[Claude] API call failed: {}", e.getMessage(), e);
+			throw new ApiException(ErrorCode.AI_ANALYSIS_FAILED, e.getMessage());
+		} catch (Exception e) {
+			log.error("[Claude] Unexpected error: {}", e.getMessage(), e);
+			throw new ApiException(ErrorCode.AI_ANALYSIS_FAILED, e.getMessage());
+		}
+	}
+
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	private record ClaudeResponse(List<ContentBlock> content) {}
+
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	private record ContentBlock(String type, String text) {}
+
+	private static class MultipartInputStreamFileResource extends InputStreamResource {
+
+		private final String filename;
+
+		MultipartInputStreamFileResource(InputStream in, String filename) {
+			super(in);
+			this.filename = filename;
+		}
+
+		@Override
+		public String getFilename() {
+			return filename;
+		}
+
+		@Override
+		public long contentLength() {
+			return -1;
+		}
+	}
+}

--- a/opicer-api/src/main/java/com/opicer/api/practice/presentation/PracticeAiController.java
+++ b/opicer-api/src/main/java/com/opicer/api/practice/presentation/PracticeAiController.java
@@ -1,0 +1,57 @@
+package com.opicer.api.practice.presentation;
+
+import com.opicer.api.practice.application.PracticeAiService;
+import com.opicer.api.shared.presentation.ApiResponse;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import java.util.Map;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/practice")
+public class PracticeAiController {
+
+	private final PracticeAiService practiceAiService;
+
+	public PracticeAiController(PracticeAiService practiceAiService) {
+		this.practiceAiService = practiceAiService;
+	}
+
+	@PostMapping(value = "/transcribe", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	public ApiResponse<Map<String, String>> transcribe(
+		@RequestPart("audio") MultipartFile audio,
+		@RequestParam("questionText") String questionText
+	) {
+		String transcript = practiceAiService.transcribe(audio, questionText);
+		return ApiResponse.ok("Transcription complete", Map.of("transcript", transcript));
+	}
+
+	@PostMapping("/analyze")
+	public ApiResponse<Map<String, String>> analyze(@Valid @RequestBody AnalyzeRequest request) {
+		String analysis = practiceAiService.analyze(request.questionText(), request.transcript());
+		return ApiResponse.ok("Analysis complete", Map.of("analysis", analysis));
+	}
+
+	@PostMapping("/improve")
+	public ApiResponse<Map<String, String>> improve(@Valid @RequestBody ImproveRequest request) {
+		String improved = practiceAiService.improve(request.questionText(), request.transcript());
+		return ApiResponse.ok("Improvement complete", Map.of("improved", improved));
+	}
+
+	record AnalyzeRequest(
+		@NotBlank String questionText,
+		@NotBlank String transcript
+	) {}
+
+	record ImproveRequest(
+		@NotBlank String questionText,
+		@NotBlank String transcript
+	) {}
+}

--- a/opicer-api/src/main/java/com/opicer/api/prompt/application/PromptVersionService.java
+++ b/opicer-api/src/main/java/com/opicer/api/prompt/application/PromptVersionService.java
@@ -28,6 +28,11 @@ public class PromptVersionService {
 		return promptVersionRepository.findById(id);
 	}
 
+	@Transactional(readOnly = true)
+	public Optional<PromptVersion> findActiveByUseCase(PromptUseCase useCase) {
+		return promptVersionRepository.findByUseCaseAndActiveTrue(useCase);
+	}
+
 	@Transactional
 	public PromptVersion create(PromptUseCase useCase, int version, String name, String template) {
 		PromptVersion promptVersion = new PromptVersion(useCase, version, name, template);

--- a/opicer-api/src/main/java/com/opicer/api/shared/error/ErrorCode.java
+++ b/opicer-api/src/main/java/com/opicer/api/shared/error/ErrorCode.java
@@ -15,7 +15,10 @@ public enum ErrorCode {
 	VALIDATION_ERROR("VALIDATION_ERROR", HttpStatus.BAD_REQUEST, "Validation failed"),
 	BAD_REQUEST("BAD_REQUEST", HttpStatus.BAD_REQUEST, "Bad request"),
 	DATA_INTEGRITY_VIOLATION("DATA_INTEGRITY_VIOLATION", HttpStatus.CONFLICT, "Data integrity violation"),
-	INTERNAL_ERROR("INTERNAL_ERROR", HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error");
+	INTERNAL_ERROR("INTERNAL_ERROR", HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error"),
+	AI_NOT_CONFIGURED("AI_NOT_CONFIGURED", HttpStatus.SERVICE_UNAVAILABLE, "AI service is not configured"),
+	AI_TRANSCRIPTION_FAILED("AI_TRANSCRIPTION_FAILED", HttpStatus.BAD_GATEWAY, "Audio transcription failed"),
+	AI_ANALYSIS_FAILED("AI_ANALYSIS_FAILED", HttpStatus.BAD_GATEWAY, "AI analysis failed");
 
 	private final String code;
 	private final HttpStatus httpStatus;

--- a/opicer-api/src/main/resources/application.yaml
+++ b/opicer-api/src/main/resources/application.yaml
@@ -38,6 +38,10 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
+  servlet:
+    multipart:
+      max-file-size: 25MB
+      max-request-size: 26MB
 
 opicer:
   auth:
@@ -47,3 +51,6 @@ opicer:
     cookie-secure: ${JWT_COOKIE_SECURE:false}
     admin-allowlist: ${ADMIN_EMAIL_ALLOWLIST:}
     frontend-base-url: ${FRONTEND_BASE_URL:http://localhost:3000}
+  ai:
+    openai-api-key: ${OPENAI_API_KEY:}
+    anthropic-api-key: ${ANTHROPIC_API_KEY:}

--- a/opicer-api/src/test/java/com/opicer/api/practice/presentation/PracticeAiControllerTest.java
+++ b/opicer-api/src/test/java/com/opicer/api/practice/presentation/PracticeAiControllerTest.java
@@ -1,0 +1,161 @@
+package com.opicer.api.practice.presentation;
+
+import com.opicer.api.auth.application.JwtService;
+import com.opicer.api.auth.domain.AuthUserPrincipal;
+import com.opicer.api.config.AuthProperties;
+import com.opicer.api.practice.application.PracticeAiService;
+import com.opicer.api.shared.error.ApiException;
+import com.opicer.api.shared.error.ErrorCode;
+import jakarta.servlet.http.Cookie;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.opicer.api.user.domain.AuthProvider;
+import com.opicer.api.user.domain.UserRole;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class PracticeAiControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JwtService jwtService;
+
+	@Autowired
+	private AuthProperties authProperties;
+
+	@MockBean
+	private PracticeAiService practiceAiService;
+
+	private Cookie userCookie;
+
+	@BeforeEach
+	void setUp() {
+		userCookie = new Cookie(authProperties.getCookieName(), jwtService.issueToken(
+			new AuthUserPrincipal(
+				UUID.randomUUID(),
+				"user@example.com",
+				"User",
+				UserRole.USER,
+				AuthProvider.KAKAO
+			)
+		));
+	}
+
+	// T1: POST /transcribe valid multipart + auth → 200
+	@Test
+	void transcribe_validRequest_returns200() throws Exception {
+		when(practiceAiService.transcribe(any(), anyString())).thenReturn("Hello world");
+
+		MockMultipartFile audioFile = new MockMultipartFile(
+			"audio", "audio.webm", "audio/webm", "fake-audio".getBytes());
+
+		mockMvc.perform(multipart("/api/practice/transcribe")
+				.file(audioFile)
+				.param("questionText", "Tell me about yourself.")
+				.cookie(userCookie))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.transcript").value("Hello world"));
+	}
+
+	// T2: POST /transcribe 인증 없음 → 401
+	@Test
+	void transcribe_noAuth_returns401() throws Exception {
+		MockMultipartFile audioFile = new MockMultipartFile(
+			"audio", "audio.webm", "audio/webm", "fake-audio".getBytes());
+
+		mockMvc.perform(multipart("/api/practice/transcribe")
+				.file(audioFile)
+				.param("questionText", "Tell me about yourself."))
+			.andExpect(status().isUnauthorized());
+	}
+
+	// T3: POST /transcribe AI_NOT_CONFIGURED → 503
+	@Test
+	void transcribe_aiNotConfigured_returns503() throws Exception {
+		when(practiceAiService.transcribe(any(), anyString()))
+			.thenThrow(new ApiException(ErrorCode.AI_NOT_CONFIGURED));
+
+		MockMultipartFile audioFile = new MockMultipartFile(
+			"audio", "audio.webm", "audio/webm", "fake-audio".getBytes());
+
+		mockMvc.perform(multipart("/api/practice/transcribe")
+				.file(audioFile)
+				.param("questionText", "Tell me about yourself.")
+				.cookie(userCookie))
+			.andExpect(status().isServiceUnavailable())
+			.andExpect(jsonPath("$.code").value("AI_NOT_CONFIGURED"));
+	}
+
+	// T4: POST /analyze valid JSON + auth → 200
+	@Test
+	void analyze_validRequest_returns200() throws Exception {
+		when(practiceAiService.analyze(anyString(), anyString())).thenReturn("Analysis result");
+
+		mockMvc.perform(post("/api/practice/analyze")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"questionText\":\"Tell me about yourself.\",\"transcript\":\"I am a student.\"}")
+				.cookie(userCookie))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.analysis").value("Analysis result"));
+	}
+
+	// T5: POST /analyze 인증 없음 → 401
+	@Test
+	void analyze_noAuth_returns401() throws Exception {
+		mockMvc.perform(post("/api/practice/analyze")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"questionText\":\"Tell me about yourself.\",\"transcript\":\"I am a student.\"}"))
+			.andExpect(status().isUnauthorized());
+	}
+
+	// T6: POST /analyze blank fields → 400
+	@Test
+	void analyze_blankFields_returns400() throws Exception {
+		mockMvc.perform(post("/api/practice/analyze")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"questionText\":\"\",\"transcript\":\"\"}")
+				.cookie(userCookie))
+			.andExpect(status().isBadRequest());
+	}
+
+	// T7: POST /improve valid JSON + auth → 200
+	@Test
+	void improve_validRequest_returns200() throws Exception {
+		when(practiceAiService.improve(anyString(), anyString())).thenReturn("Improved script");
+
+		mockMvc.perform(post("/api/practice/improve")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"questionText\":\"Tell me about yourself.\",\"transcript\":\"I am a student.\"}")
+				.cookie(userCookie))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.improved").value("Improved script"));
+	}
+
+	// T8: POST /improve 인증 없음 → 401
+	@Test
+	void improve_noAuth_returns401() throws Exception {
+		mockMvc.perform(post("/api/practice/improve")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"questionText\":\"Tell me about yourself.\",\"transcript\":\"I am a student.\"}"))
+			.andExpect(status().isUnauthorized());
+	}
+}

--- a/opicer-web/package.json
+++ b/opicer-web/package.json
@@ -9,12 +9,14 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "diff": "^8.0.3",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@types/diff": "^8.0.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/opicer-web/pnpm-lock.yaml
+++ b/opicer-web/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      diff:
+        specifier: ^8.0.3
+        version: 8.0.3
       next:
         specifier: 16.1.6
         version: 16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -21,6 +24,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.2.1
+      '@types/diff':
+        specifier: ^8.0.0
+        version: 8.0.0
       '@types/node':
         specifier: ^20
         version: 20.19.33
@@ -502,6 +508,10 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/diff@8.0.0':
+    resolution: {integrity: sha512-o7jqJM04gfaYrdCecCVMbZhNdG6T1MHg/oQoRFdERLV+4d+V7FijhiEAbFu0Usww84Yijk9yH58U4Jk4HbtzZw==}
+    deprecated: This is a stub types definition. diff provides its own type definitions, so you do not need this installed.
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -871,6 +881,10 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  diff@8.0.3:
+    resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
+    engines: {node: '>=0.3.1'}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -2343,6 +2357,10 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/diff@8.0.0':
+    dependencies:
+      diff: 8.0.3
+
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
@@ -2727,6 +2745,8 @@ snapshots:
       object-keys: 1.1.1
 
   detect-libc@2.1.2: {}
+
+  diff@8.0.3: {}
 
   doctrine@2.1.0:
     dependencies:

--- a/opicer-web/src/app/api/practice/analyze/route.ts
+++ b/opicer-web/src/app/api/practice/analyze/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const baseUrl = process.env.OPICER_API_BASE_URL || "http://localhost:8080";
+
+export async function POST(request: NextRequest) {
+  const payload = await request.text();
+
+  const res = await fetch(`${baseUrl}/api/practice/analyze`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      cookie: request.headers.get("cookie") ?? "",
+    },
+    body: payload,
+  });
+
+  const bodyText = await res.text();
+  if (!bodyText) {
+    return NextResponse.json(null, { status: res.status });
+  }
+
+  const body = JSON.parse(bodyText) as Record<string, unknown>;
+  if (!res.ok) {
+    return NextResponse.json(body, { status: res.status });
+  }
+
+  const data = (body as { data: Record<string, unknown> }).data;
+  return NextResponse.json(data, { status: res.status });
+}

--- a/opicer-web/src/app/api/practice/improve/route.ts
+++ b/opicer-web/src/app/api/practice/improve/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const baseUrl = process.env.OPICER_API_BASE_URL || "http://localhost:8080";
+
+export async function POST(request: NextRequest) {
+  const payload = await request.text();
+
+  const res = await fetch(`${baseUrl}/api/practice/improve`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      cookie: request.headers.get("cookie") ?? "",
+    },
+    body: payload,
+  });
+
+  const bodyText = await res.text();
+  if (!bodyText) {
+    return NextResponse.json(null, { status: res.status });
+  }
+
+  const body = JSON.parse(bodyText) as Record<string, unknown>;
+  if (!res.ok) {
+    return NextResponse.json(body, { status: res.status });
+  }
+
+  const data = (body as { data: Record<string, unknown> }).data;
+  return NextResponse.json(data, { status: res.status });
+}

--- a/opicer-web/src/app/api/practice/transcribe/route.ts
+++ b/opicer-web/src/app/api/practice/transcribe/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const baseUrl = process.env.OPICER_API_BASE_URL || "http://localhost:8080";
+
+export async function POST(request: NextRequest) {
+  // Forward the raw body with the original Content-Type (includes multipart boundary).
+  // Avoid request.formData() → re-serialize, which can corrupt the stream.
+  const body = await request.arrayBuffer();
+  const contentType = request.headers.get("content-type") ?? "";
+
+  const res = await fetch(`${baseUrl}/api/practice/transcribe`, {
+    method: "POST",
+    headers: {
+      "content-type": contentType,
+      cookie: request.headers.get("cookie") ?? "",
+    },
+    body,
+  });
+
+  const resText = await res.text();
+  if (!resText) {
+    return NextResponse.json(null, { status: res.status });
+  }
+
+  const resBody = JSON.parse(resText) as Record<string, unknown>;
+  if (!res.ok) {
+    return NextResponse.json(resBody, { status: res.status });
+  }
+
+  // Unwrap ApiResponse.data
+  const data = (resBody as { data: Record<string, unknown> }).data;
+  return NextResponse.json(data, { status: res.status });
+}

--- a/opicer-web/src/features/practice/api.ts
+++ b/opicer-web/src/features/practice/api.ts
@@ -4,6 +4,7 @@ import type {
   TopicSelection,
 } from "@/features/practice/types";
 
+
 export async function fetchTopics(): Promise<TopicItem[]> {
   const res = await fetch(`/api/topics`, { cache: "no-store" });
   if (!res.ok) {
@@ -41,4 +42,60 @@ export async function fetchPracticeQuestions(
     throw new Error("Failed to load practice questions");
   }
   return (await res.json()) as PracticeQuestion[];
+}
+
+export async function transcribeAudio(
+  audioUrl: string,
+  questionText: string
+): Promise<string> {
+  const audioRes = await fetch(audioUrl);
+  const audioBlob = await audioRes.blob();
+  const formData = new FormData();
+  formData.append("audio", audioBlob, "audio.webm");
+  formData.append("questionText", questionText);
+
+  const res = await fetch("/api/practice/transcribe", {
+    method: "POST",
+    body: formData,
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    throw new Error(body?.message ?? "Transcription failed");
+  }
+  const body = (await res.json()) as { transcript: string };
+  return body.transcript;
+}
+
+export async function analyzeAnswer(
+  questionText: string,
+  transcript: string
+): Promise<string> {
+  const res = await fetch("/api/practice/analyze", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ questionText, transcript }),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    throw new Error(body?.message ?? "Analysis failed");
+  }
+  const body = (await res.json()) as { analysis: string };
+  return body.analysis;
+}
+
+export async function improveScript(
+  questionText: string,
+  transcript: string
+): Promise<string> {
+  const res = await fetch("/api/practice/improve", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ questionText, transcript }),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    throw new Error(body?.message ?? "Improvement failed");
+  }
+  const body = (await res.json()) as { improved: string };
+  return body.improved;
 }

--- a/opicer-web/src/features/practice/components/PracticeSessionView.tsx
+++ b/opicer-web/src/features/practice/components/PracticeSessionView.tsx
@@ -3,12 +3,29 @@
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { TopNav } from "@/components/common/TopNav";
-import { fetchPracticeQuestions } from "@/features/practice/api";
+import {
+  analyzeAnswer,
+  fetchPracticeQuestions,
+  improveScript,
+  transcribeAudio,
+} from "@/features/practice/api";
 import { ROUTES } from "@/lib/routes";
 import type { PracticeAnswer, PracticeQuestion } from "@/features/practice/types";
+import { TranscriptDiff } from "@/features/practice/components/TranscriptDiff";
 
 const PRACTICE_DURATION_SECONDS = 120;
 const REPLAY_WINDOW_SECONDS = 5;
+
+type Mode = "loading" | "playing" | "recording" | "submitting" | "summary";
+
+type QuestionAiState = {
+  isAnalyzing: boolean;
+  analysis: string | null;
+  analyzeError: string | null;
+  isImproving: boolean;
+  improvement: string | null;
+  improveError: string | null;
+};
 
 type Props = {
   topicId: string;
@@ -23,8 +40,11 @@ export function PracticeSessionView({ topicId, userLabel, onLogout }: Props) {
   const [questions, setQuestions] = useState<PracticeQuestion[]>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [answers, setAnswers] = useState<PracticeAnswer[]>([]);
-  const [mode, setMode] = useState<"loading" | "playing" | "recording" | "summary">("loading");
+  const [mode, setMode] = useState<Mode>("loading");
   const [error, setError] = useState<string | null>(null);
+
+  // ── AI state per question ───────────────────────────────────
+  const [aiStates, setAiStates] = useState<Record<string, QuestionAiState>>({});
 
   // ── Timer / replay state ────────────────────────────────────
   const [remainingSeconds, setRemainingSeconds] = useState(PRACTICE_DURATION_SECONDS);
@@ -42,6 +62,10 @@ export function PracticeSessionView({ topicId, userLabel, onLogout }: Props) {
   const voicesRef = useRef<SpeechSynthesisVoice[]>([]);
   // Stable ref to goToNext — updated every render to avoid stale closures
   const goToNextRef = useRef<() => void>(() => {});
+  // answersRef mirrors answers state for sync access inside async callbacks
+  const answersRef = useRef<PracticeAnswer[]>([]);
+  // pendingSubmitRef signals that onstop should trigger transcription
+  const pendingSubmitRef = useRef(false);
 
   const currentQuestion = questions[currentIndex];
   const isLastQuestion = currentIndex === questions.length - 1;
@@ -66,7 +90,10 @@ export function PracticeSessionView({ topicId, userLabel, onLogout }: Props) {
         setQuestions(data);
         setMode("playing");
       })
-      .catch((err: any) => setError(err?.message ?? "질문을 불러오지 못했습니다."));
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : "질문을 불러오지 못했습니다.";
+        setError(message);
+      });
   }, [topicId]);
 
   // ── Helpers ─────────────────────────────────────────────────
@@ -119,8 +146,27 @@ export function PracticeSessionView({ topicId, userLabel, onLogout }: Props) {
     }
   };
 
-  // ── startRecording: use recorderRef.current check (not isRecording state)
-  //    to avoid stale closure bug when called from audio onended callbacks
+  // ── Transcribe all answers and switch to summary ─────────────
+  const doTranscribeAndSummary = (snapshot: PracticeAnswer[]) => {
+    setMode("submitting");
+    Promise.all(
+      snapshot.map(async (a) => {
+        if (!a.audioUrl) return a;
+        try {
+          const transcript = await transcribeAudio(a.audioUrl, a.questionText);
+          return { ...a, transcript };
+        } catch (err) {
+          const transcribeError = err instanceof Error ? err.message : "전사 실패";
+          return { ...a, transcribeError };
+        }
+      })
+    ).then((updated) => {
+      answersRef.current = updated;
+      setAnswers(updated);
+      setMode("summary");
+    });
+  };
+
   const startRecording = async (question: PracticeQuestion) => {
     if (recorderRef.current && recorderRef.current.state !== "inactive") return;
     try {
@@ -134,18 +180,25 @@ export function PracticeSessionView({ topicId, userLabel, onLogout }: Props) {
         stream.getTracks().forEach((t) => t.stop());
         const blob = new Blob(chunksRef.current, { type: "audio/webm" });
         const url = URL.createObjectURL(blob);
-        setAnswers((prev) => {
-          const next = prev.filter((a) => a.questionId !== question.id);
-          return [
-            ...next,
-            {
-              questionId: question.id,
-              questionText: question.promptText,
-              audioUrl: url,
-              recordedAt: new Date().toISOString(),
-            },
-          ];
-        });
+        const newAnswer: PracticeAnswer = {
+          questionId: question.id,
+          questionText: question.promptText,
+          audioUrl: url,
+          recordedAt: new Date().toISOString(),
+        };
+        // Sync update answersRef first, then state
+        const nextAnswers = [
+          ...answersRef.current.filter((a) => a.questionId !== question.id),
+          newAnswer,
+        ];
+        answersRef.current = nextAnswers;
+        setAnswers(nextAnswers);
+
+        // If submit was requested while recording was active, now safe to transcribe
+        if (pendingSubmitRef.current) {
+          pendingSubmitRef.current = false;
+          doTranscribeAndSummary(nextAnswers);
+        }
       };
       recorderRef.current = recorder;
       recorder.start();
@@ -155,7 +208,6 @@ export function PracticeSessionView({ topicId, userLabel, onLogout }: Props) {
     }
   };
 
-  // startTimer: only clears main timer (NOT replay timer)
   const startTimer = () => {
     clearMainTimer();
     setRemainingSeconds(PRACTICE_DURATION_SECONDS);
@@ -187,7 +239,6 @@ export function PracticeSessionView({ topicId, userLabel, onLogout }: Props) {
     }, 1000);
   };
 
-  // ── Play audio for a question, call onEnded when done ───────
   const playQuestionAudio = (question: PracticeQuestion, onEnded: () => void) => {
     if (question.promptAudioUrl) {
       if (!audioRef.current) audioRef.current = new Audio(question.promptAudioUrl);
@@ -206,16 +257,24 @@ export function PracticeSessionView({ topicId, userLabel, onLogout }: Props) {
     }
   };
 
-  // ── goToNext / goToSummary ───────────────────────────────────
   const goToNext = () => {
-    stopAll();
     setHasReplayed(false);
     setReplayWindow(0);
     setRemainingSeconds(PRACTICE_DURATION_SECONDS);
     setTimeExpired(false);
     if (isLastQuestion) {
-      setMode("summary");
+      if (recorderRef.current && recorderRef.current.state !== "inactive") {
+        // Recording is active → flag it; onstop will call doTranscribeAndSummary
+        pendingSubmitRef.current = true;
+        stopAll();
+        setMode("submitting");
+      } else {
+        // No active recording → safe to submit immediately
+        stopAll();
+        doTranscribeAndSummary(answersRef.current);
+      }
     } else {
+      stopAll();
       setMode("playing");
       setCurrentIndex((prev) => prev + 1);
     }
@@ -239,15 +298,11 @@ export function PracticeSessionView({ topicId, userLabel, onLogout }: Props) {
     const question = questions[currentIndex];
     if (!question) return;
 
-    // Reset state
     setHasReplayed(false);
     setReplayWindow(0);
     setRemainingSeconds(PRACTICE_DURATION_SECONDS);
     setTimeExpired(false);
 
-    // Auto-play → when done: startReplayWindow + startRecording + startTimer
-    // Note: startReplayWindow MUST be called AFTER startTimer to avoid
-    //       startTimer's clearMainTimer accidentally clearing the replay timer
     playQuestionAudio(question, () => {
       setMode("recording");
       startRecording(question);
@@ -282,6 +337,57 @@ export function PracticeSessionView({ topicId, userLabel, onLogout }: Props) {
     });
   };
 
+  // ── AI actions ───────────────────────────────────────────────
+  const getOrInitAiState = (questionId: string): QuestionAiState =>
+    aiStates[questionId] ?? {
+      isAnalyzing: false, analysis: null, analyzeError: null,
+      isImproving: false, improvement: null, improveError: null,
+    };
+
+  const handleAnalyze = async (answer: PracticeAnswer) => {
+    if (!answer.transcript) return;
+    const id = answer.questionId;
+    setAiStates((prev) => ({
+      ...prev,
+      [id]: { ...getOrInitAiState(id), isAnalyzing: true, analyzeError: null },
+    }));
+    try {
+      const analysis = await analyzeAnswer(answer.questionText, answer.transcript);
+      setAiStates((prev) => ({
+        ...prev,
+        [id]: { ...prev[id]!, isAnalyzing: false, analysis },
+      }));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "분석에 실패했습니다.";
+      setAiStates((prev) => ({
+        ...prev,
+        [id]: { ...prev[id]!, isAnalyzing: false, analyzeError: message },
+      }));
+    }
+  };
+
+  const handleImprove = async (answer: PracticeAnswer) => {
+    if (!answer.transcript) return;
+    const id = answer.questionId;
+    setAiStates((prev) => ({
+      ...prev,
+      [id]: { ...getOrInitAiState(id), isImproving: true, improveError: null },
+    }));
+    try {
+      const improvement = await improveScript(answer.questionText, answer.transcript);
+      setAiStates((prev) => ({
+        ...prev,
+        [id]: { ...prev[id]!, isImproving: false, improvement },
+      }));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "수정에 실패했습니다.";
+      setAiStates((prev) => ({
+        ...prev,
+        [id]: { ...prev[id]!, isImproving: false, improveError: message },
+      }));
+    }
+  };
+
   // ── Cleanup on unmount ───────────────────────────────────────
   useEffect(() => {
     return () => { stopAll(); };
@@ -290,6 +396,21 @@ export function PracticeSessionView({ topicId, userLabel, onLogout }: Props) {
 
   const topicTitle = currentQuestion?.topic ?? questions[0]?.topic ?? "연습";
   const warning = remainingSeconds <= 10 && remainingSeconds > 0;
+
+  // ── Submitting screen ────────────────────────────────────────
+  if (mode === "submitting") {
+    return (
+      <div className="min-h-screen px-6 py-10 text-[var(--ink)]">
+        <div className="mx-auto flex max-w-4xl flex-col gap-8">
+          <TopNav userLabel={userLabel} onLogout={onLogout} />
+          <div className="flex flex-col items-center justify-center py-24 gap-4">
+            <div className="h-8 w-8 animate-spin rounded-full border-2 border-[var(--accent)] border-t-transparent" />
+            <p className="text-sm text-[var(--muted)]">답변 분석 중…</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   // ── Summary screen ───────────────────────────────────────────
   if (mode === "summary") {
@@ -305,25 +426,91 @@ export function PracticeSessionView({ topicId, userLabel, onLogout }: Props) {
           </section>
 
           <div className="space-y-6">
-            {answers.map((answer, idx) => (
-              <div
-                key={answer.questionId}
-                className="rounded-[24px] border border-black/10 bg-white/70 p-5 shadow-sm"
-              >
-                <p className="text-xs uppercase tracking-[0.2em] text-[var(--muted)]">
-                  Question {idx + 1}
-                </p>
-                <p className="mt-2 text-base font-semibold">{answer.questionText}</p>
-                <div className="mt-4 rounded-2xl border border-[var(--accent)]/20 bg-[var(--accent)]/10 p-4">
-                  <p className="text-xs font-semibold text-[var(--accent-strong)]">Your Answer</p>
-                  {answer.audioUrl ? (
-                    <audio controls src={answer.audioUrl} className="mt-2 w-full" />
-                  ) : (
-                    <p className="mt-2 text-sm text-[var(--muted)]">녹음된 답변이 없습니다.</p>
+            {answers.map((answer, idx) => {
+              const ai = getOrInitAiState(answer.questionId);
+              return (
+                <div
+                  key={answer.questionId}
+                  className="rounded-[24px] border border-black/10 bg-white/70 p-5 shadow-sm"
+                >
+                  <p className="text-xs uppercase tracking-[0.2em] text-[var(--muted)]">
+                    Question {idx + 1}
+                  </p>
+                  <p className="mt-2 text-base font-semibold">{answer.questionText}</p>
+
+                  {/* Transcript + audio */}
+                  <div className="mt-4 rounded-2xl border border-[var(--accent)]/20 bg-[var(--accent)]/10 p-4">
+                    <p className="text-xs font-semibold text-[var(--accent-strong)]">Your Answer</p>
+                    {answer.transcript ? (
+                      <p className="mt-2 text-sm leading-relaxed">{answer.transcript}</p>
+                    ) : answer.transcribeError ? (
+                      <p className="mt-2 text-sm text-red-500">전사 실패: {answer.transcribeError}</p>
+                    ) : (
+                      <p className="mt-2 text-sm text-[var(--muted)]">전사 텍스트 없음</p>
+                    )}
+                    {answer.audioUrl ? (
+                      <audio controls src={answer.audioUrl} className="mt-3 w-full" />
+                    ) : (
+                      <p className="mt-2 text-sm text-[var(--muted)]">녹음된 답변이 없습니다.</p>
+                    )}
+                  </div>
+
+                  {/* Action buttons — only if transcript exists */}
+                  {answer.transcript && (
+                    <div className="mt-4 flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        onClick={() => handleAnalyze(answer)}
+                        disabled={ai.isAnalyzing || ai.analysis !== null}
+                        className={`rounded-full px-5 py-2 text-sm font-semibold transition-colors ${
+                          ai.isAnalyzing || ai.analysis !== null
+                            ? "cursor-not-allowed bg-black/5 text-[var(--muted)]"
+                            : "bg-[var(--accent)] text-white hover:bg-[var(--accent-strong)]"
+                        }`}
+                      >
+                        {ai.isAnalyzing ? "분석 중…" : ai.analysis ? "분석 완료" : "분석하기"}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleImprove(answer)}
+                        disabled={ai.isImproving || ai.improvement !== null}
+                        className={`rounded-full px-5 py-2 text-sm font-semibold transition-colors ${
+                          ai.isImproving || ai.improvement !== null
+                            ? "cursor-not-allowed bg-black/5 text-[var(--muted)]"
+                            : "bg-black text-white hover:bg-black/80"
+                        }`}
+                      >
+                        {ai.isImproving ? "수정 중…" : ai.improvement ? "수정 완료" : "수정하기"}
+                      </button>
+                    </div>
+                  )}
+
+                  {/* Analysis result */}
+                  {ai.analyzeError && (
+                    <p className="mt-3 text-sm text-red-600">{ai.analyzeError}</p>
+                  )}
+                  {ai.analysis && (
+                    <div className="mt-4 rounded-2xl border border-black/10 bg-white/80 p-4 text-sm leading-relaxed whitespace-pre-wrap">
+                      <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-[var(--muted)]">AI 분석</p>
+                      {ai.analysis}
+                    </div>
+                  )}
+
+                  {/* Improvement diff */}
+                  {ai.improveError && (
+                    <p className="mt-3 text-sm text-red-600">{ai.improveError}</p>
+                  )}
+                  {ai.improvement && answer.transcript && (
+                    <div className="mt-4">
+                      <TranscriptDiff
+                        original={answer.transcript}
+                        improved={ai.improvement}
+                      />
+                    </div>
                   )}
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
 
           <div className="flex flex-col items-center gap-3 pb-10">
@@ -337,7 +524,9 @@ export function PracticeSessionView({ topicId, userLabel, onLogout }: Props) {
             <button
               type="button"
               onClick={() => {
+                answersRef.current = [];
                 setAnswers([]);
+                setAiStates({});
                 setCurrentIndex(0);
                 setMode("playing");
               }}

--- a/opicer-web/src/features/practice/components/TranscriptDiff.tsx
+++ b/opicer-web/src/features/practice/components/TranscriptDiff.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { diffWords } from "diff";
+
+type Props = {
+  original: string;
+  improved: string;
+};
+
+export function TranscriptDiff({ original, improved }: Props) {
+  const changes = diffWords(original, improved);
+
+  return (
+    <div className="rounded-2xl border border-black/10 bg-white/80 p-4 text-sm leading-relaxed">
+      <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-[var(--muted)]">
+        개선 스크립트
+      </p>
+      <p className="flex flex-wrap gap-y-1">
+        {changes.map((change, idx) => {
+          if (change.removed) {
+            return (
+              <span
+                key={idx}
+                className="line-through text-red-500 opacity-70 mr-1"
+              >
+                {change.value}
+              </span>
+            );
+          }
+          if (change.added) {
+            return (
+              <span
+                key={idx}
+                className="bg-green-100 text-green-800 rounded px-0.5 mr-1"
+              >
+                {change.value}
+              </span>
+            );
+          }
+          return (
+            <span key={idx} className="mr-1">
+              {change.value}
+            </span>
+          );
+        })}
+      </p>
+    </div>
+  );
+}

--- a/opicer-web/src/features/practice/types.ts
+++ b/opicer-web/src/features/practice/types.ts
@@ -43,4 +43,14 @@ export type PracticeAnswer = {
   questionText: string;
   audioUrl?: string;
   recordedAt?: string;
+  transcript?: string;
+  transcribeError?: string;
+};
+
+export type AnalysisResult = {
+  analysis: string;
+};
+
+export type ImprovementResult = {
+  improved: string;
 };


### PR DESCRIPTION
## Background and Purpose
주제별 연습하기에 AI 연동을 추가해, 질문 분석/개선/전사 흐름을 구성한다.

## What changed
- Backend AI 설정/서비스/컨트롤러 및 테스트 추가
- 프롬프트/에러코드/설정 반영
- Frontend API 라우트(`/api/practice/analyze|improve|transcribe`) 및 클라이언트 흐름 추가
- 연습 화면에서 AI 분석 결과를 보여주는 UI 구성(TranscriptDiff 포함)
- 웹 의존성 업데이트

## How to test
1. API 엔드포인트 확인
2. 연습 화면에서 분석/개선/전사 흐름 호출

## Risk / Rollback
- Risk: Medium (AI 호출/의존성 추가)
- Rollback: PR revert

## Checklist
- [ ] Tests passing
- [x] No unrelated files included

Closes #52