### PR TITLE
[Feature] Support multi-file audio upload

### DIFF
--- a/opicer-api/src/main/java/com/opicer/api/goodanswer/application/GoodAnswerSampleService.java
+++ b/opicer-api/src/main/java/com/opicer/api/goodanswer/application/GoodAnswerSampleService.java
@@ -51,14 +51,21 @@ public class GoodAnswerSampleService {
 	}
 
 	@Transactional
-	public GoodAnswerSample createFromAudio(UUID topicId, OpicLevel level, MultipartFile audio,
+	public List<GoodAnswerSample> createFromAudio(UUID topicId, OpicLevel level, List<MultipartFile> audios,
 		String summary, List<String> tags, List<String> keyExpressions) {
-		String audioUrl = audioStorage.save(audio);
-		String transcript = transcriptionService.transcribe(audio);
-		if (transcript == null || transcript.isBlank()) {
-			throw new ApiException(ErrorCode.AI_TRANSCRIPTION_FAILED, "Empty transcript");
+		if (audios == null || audios.isEmpty()) {
+			throw new ApiException(ErrorCode.VALIDATION_ERROR, "Audio file is required");
 		}
-		return create(topicId, level, transcript.trim(), audioUrl, summary, tags, keyExpressions);
+		return audios.stream()
+			.map(audio -> {
+				String audioUrl = audioStorage.save(audio);
+				String transcript = transcriptionService.transcribe(audio);
+				if (transcript == null || transcript.isBlank()) {
+					throw new ApiException(ErrorCode.AI_TRANSCRIPTION_FAILED, "Empty transcript");
+				}
+				return create(topicId, level, transcript.trim(), audioUrl, summary, tags, keyExpressions);
+			})
+			.toList();
 	}
 
 	@Transactional(readOnly = true)

--- a/opicer-api/src/main/java/com/opicer/api/goodanswer/presentation/AdminGoodAnswerSampleController.java
+++ b/opicer-api/src/main/java/com/opicer/api/goodanswer/presentation/AdminGoodAnswerSampleController.java
@@ -52,15 +52,15 @@ public class AdminGoodAnswerSampleController {
 	}
 
 	@PostMapping(value = "/audio", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-	public ApiResponse<Map<String, Object>> createFromAudio(
-		@RequestPart("audio") MultipartFile audio,
+	public ApiResponse<List<Map<String, Object>>> createFromAudio(
+		@RequestPart("audio") List<MultipartFile> audio,
 		@RequestParam UUID topicId,
 		@RequestParam OpicLevel level,
 		@RequestParam(required = false) String summary,
 		@RequestParam(required = false) String tags,
 		@RequestParam(required = false) String keyExpressions
 	) {
-		GoodAnswerSample sample = service.createFromAudio(
+		List<GoodAnswerSample> samples = service.createFromAudio(
 			topicId,
 			level,
 			audio,
@@ -68,13 +68,16 @@ public class AdminGoodAnswerSampleController {
 			parseCsv(tags),
 			parseCsv(keyExpressions)
 		);
-		return ApiResponse.ok("Good answer sample created", Map.of(
-			"id", sample.getId(),
-			"createdAt", sample.getCreatedAt(),
-			"updatedAt", sample.getUpdatedAt(),
-			"audioUrl", sample.getSampleAudioUrl(),
-			"sampleText", sample.getSampleText()
-		));
+		List<Map<String, Object>> result = samples.stream()
+			.map(sample -> Map.of(
+				"id", sample.getId(),
+				"createdAt", sample.getCreatedAt(),
+				"updatedAt", sample.getUpdatedAt(),
+				"audioUrl", sample.getSampleAudioUrl(),
+				"sampleText", sample.getSampleText()
+			))
+			.toList();
+		return ApiResponse.ok("Good answer samples created", result);
 	}
 
 	@GetMapping

--- a/opicer-api/src/test/java/com/opicer/api/goodanswer/presentation/AdminGoodAnswerSampleControllerTest.java
+++ b/opicer-api/src/test/java/com/opicer/api/goodanswer/presentation/AdminGoodAnswerSampleControllerTest.java
@@ -154,7 +154,7 @@ class AdminGoodAnswerSampleControllerTest {
 		ReflectionTestUtils.setField(sample, "updatedAt", java.time.Instant.now());
 
 		when(service.createFromAudio(eq(topicId), eq(OpicLevel.IM), any(), any(), anyList(), anyList()))
-			.thenReturn(sample);
+			.thenReturn(List.of(sample));
 
 		MockMultipartFile file = new MockMultipartFile(
 			"audio",
@@ -172,9 +172,9 @@ class AdminGoodAnswerSampleControllerTest {
 				.param("keyExpressions", "expr1")
 				.cookie(adminCookie))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.data.id").exists())
-			.andExpect(jsonPath("$.data.sampleText").value("sample text"))
-			.andExpect(jsonPath("$.data.audioUrl").value("/media/good-answers/sample.webm"));
+			.andExpect(jsonPath("$.data[0].id").exists())
+			.andExpect(jsonPath("$.data[0].sampleText").value("sample text"))
+			.andExpect(jsonPath("$.data[0].audioUrl").value("/media/good-answers/sample.webm"));
 	}
 
 	@Test

--- a/opicer-web/src/features/admin/api.ts
+++ b/opicer-web/src/features/admin/api.ts
@@ -6,7 +6,7 @@ import type {
   Question,
   QuestionType,
   GoodAnswerSample,
-  GoodAnswerUploadResponse,
+  GoodAnswerUploadItem,
   UniversalSentence,
   UniversalSentenceType,
 } from "./types";
@@ -198,19 +198,19 @@ export const goodAnswerApi = {
   upload: (data: {
     topicId: string;
     level: OpicLevel;
-    audio: File;
+    audio: File[];
     summary?: string;
     tags?: string;
     keyExpressions?: string;
   }) => {
     const formData = new FormData();
-    formData.append("audio", data.audio);
+    data.audio.forEach((file) => formData.append("audio", file));
     formData.append("topicId", data.topicId);
     formData.append("level", data.level);
     if (data.summary) formData.append("summary", data.summary);
     if (data.tags) formData.append("tags", data.tags);
     if (data.keyExpressions) formData.append("keyExpressions", data.keyExpressions);
-    return requestForm<GoodAnswerUploadResponse>("good-answers/audio", formData);
+    return requestForm<GoodAnswerUploadItem[]>("good-answers/audio", formData);
   },
   delete: (id: string) =>
     request<void>(`good-answers/${id}`, { method: "DELETE" }),

--- a/opicer-web/src/features/admin/types.ts
+++ b/opicer-web/src/features/admin/types.ts
@@ -75,7 +75,7 @@ export type GoodAnswerSample = {
   createdAt: string;
 };
 
-export type GoodAnswerUploadResponse = {
+export type GoodAnswerUploadItem = {
   id: string;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## Background and Purpose
Add multi-file upload support for good answer audio samples (backend + admin API types).

## What changed
- Accept multiple audio files in admin upload endpoint
- Adjust response to list payloads
- Update admin API typings

## How to test
- `./gradlew test` (not run in this PR)

## Risk / Rollback
- Low. Revert this commit if needed.

## Non-goals
- UI changes (already in previous PR)

## Checklist
- [ ] Tests passing (`./gradlew test`)
- [ ] No unrelated files included

Closes #54