### PR TITLE
[Feature] Add idempotency key handling for credit payment confirm

### DIFF
--- a/opicer-api/src/main/java/com/opicer/api/config/CreditProperties.java
+++ b/opicer-api/src/main/java/com/opicer/api/config/CreditProperties.java
@@ -6,6 +6,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class CreditProperties {
 
 	private long unsafeDelayMs = 0;
+	private long idempotencyTtlHours = 24;
 
 	public long getUnsafeDelayMs() {
 		return unsafeDelayMs;
@@ -13,5 +14,13 @@ public class CreditProperties {
 
 	public void setUnsafeDelayMs(long unsafeDelayMs) {
 		this.unsafeDelayMs = unsafeDelayMs;
+	}
+
+	public long getIdempotencyTtlHours() {
+		return idempotencyTtlHours;
+	}
+
+	public void setIdempotencyTtlHours(long idempotencyTtlHours) {
+		this.idempotencyTtlHours = idempotencyTtlHours;
 	}
 }

--- a/opicer-api/src/main/java/com/opicer/api/credit/application/CreditPaymentService.java
+++ b/opicer-api/src/main/java/com/opicer/api/credit/application/CreditPaymentService.java
@@ -1,14 +1,28 @@
 package com.opicer.api.credit.application;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.opicer.api.config.CreditProperties;
 import com.opicer.api.credit.domain.CreditOrder;
 import com.opicer.api.credit.domain.CreditPayment;
+import com.opicer.api.credit.domain.CreditPaymentIdempotency;
 import com.opicer.api.credit.domain.CreditPaymentStatus;
 import com.opicer.api.credit.domain.MockPaymentDecision;
 import com.opicer.api.credit.domain.MockPaymentRecord;
+import com.opicer.api.credit.infrastructure.CreditPaymentIdempotencyRepository;
 import com.opicer.api.credit.infrastructure.CreditPaymentRepository;
 import com.opicer.api.credit.infrastructure.MockPaymentRecordRepository;
+import com.opicer.api.shared.error.ApiException;
+import com.opicer.api.shared.error.ErrorCode;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.HexFormat;
 import java.util.UUID;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,22 +31,28 @@ public class CreditPaymentService {
 
 	private final CreditOrderService creditOrderService;
 	private final CreditPaymentRepository creditPaymentRepository;
+	private final CreditPaymentIdempotencyRepository creditPaymentIdempotencyRepository;
 	private final MockPaymentRecordRepository mockPaymentRecordRepository;
 	private final CreditProperties creditProperties;
 	private final CreditBalanceService creditBalanceService;
+	private final ObjectMapper objectMapper;
 
 	public CreditPaymentService(
 		CreditOrderService creditOrderService,
 		CreditPaymentRepository creditPaymentRepository,
+		CreditPaymentIdempotencyRepository creditPaymentIdempotencyRepository,
 		MockPaymentRecordRepository mockPaymentRecordRepository,
 		CreditProperties creditProperties,
-		CreditBalanceService creditBalanceService
+		CreditBalanceService creditBalanceService,
+		ObjectMapper objectMapper
 	) {
 		this.creditOrderService = creditOrderService;
 		this.creditPaymentRepository = creditPaymentRepository;
+		this.creditPaymentIdempotencyRepository = creditPaymentIdempotencyRepository;
 		this.mockPaymentRecordRepository = mockPaymentRecordRepository;
 		this.creditProperties = creditProperties;
 		this.creditBalanceService = creditBalanceService;
+		this.objectMapper = objectMapper;
 	}
 
 	@Transactional
@@ -54,6 +74,96 @@ public class CreditPaymentService {
 			});
 	}
 
+	@Transactional
+	public CreditPayment confirmPaymentWithIdempotency(UUID orderId, String providerTxId, String idempotencyKey) {
+		if (idempotencyKey == null || idempotencyKey.isBlank()) {
+			throw new ApiException(ErrorCode.VALIDATION_ERROR, "Idempotency-Key header is required");
+		}
+		CreditOrder order = creditOrderService.getOrder(orderId);
+		String requestHash = computeRequestHash(orderId, providerTxId);
+		Instant now = Instant.now();
+		Instant expiresAt = now.plus(creditProperties.getIdempotencyTtlHours(), ChronoUnit.HOURS);
+		CreditPaymentIdempotency idem = acquireIdempotency(order.getUserId(), idempotencyKey, requestHash, now, expiresAt);
+
+		if (idem.isCompleted()) {
+			return creditPaymentRepository.findById(idem.getPaymentId())
+				.orElseThrow(() -> new ApiException(ErrorCode.INTERNAL_ERROR, "Saved idempotency response is invalid"));
+		}
+
+		CreditPayment payment = confirmPayment(orderId, providerTxId);
+		idem.complete(payment.getId(), HttpStatus.OK.value(), toSnapshot(payment));
+		creditPaymentIdempotencyRepository.save(idem);
+		return payment;
+	}
+
+	private CreditPaymentIdempotency acquireIdempotency(
+		UUID userId,
+		String idempotencyKey,
+		String requestHash,
+		Instant now,
+		Instant expiresAt
+	) {
+		CreditPaymentIdempotency existing = creditPaymentIdempotencyRepository
+			.findForUpdate(userId, idempotencyKey)
+			.orElse(null);
+		if (existing != null) {
+			return validateOrReuse(existing, requestHash, now, expiresAt);
+		}
+
+		try {
+			CreditPaymentIdempotency created = creditPaymentIdempotencyRepository
+				.saveAndFlush(new CreditPaymentIdempotency(userId, idempotencyKey, requestHash, expiresAt));
+			return created;
+		} catch (DataIntegrityViolationException ex) {
+			CreditPaymentIdempotency conflicted = creditPaymentIdempotencyRepository
+				.findForUpdate(userId, idempotencyKey)
+				.orElseThrow(() -> new ApiException(ErrorCode.INTERNAL_ERROR, "Failed to read idempotency key"));
+			return validateOrReuse(conflicted, requestHash, now, expiresAt);
+		}
+	}
+
+	private CreditPaymentIdempotency validateOrReuse(
+		CreditPaymentIdempotency existing,
+		String requestHash,
+		Instant now,
+		Instant expiresAt
+	) {
+		if (existing.getExpiresAt().isBefore(now)) {
+			existing.refreshForNewRequest(requestHash, expiresAt);
+			return creditPaymentIdempotencyRepository.save(existing);
+		}
+		if (!existing.getRequestHash().equals(requestHash)) {
+			throw new ApiException(ErrorCode.IDEMPOTENCY_KEY_CONFLICT,
+				"Idempotency-Key already used with different request payload");
+		}
+		return existing;
+	}
+
+	private String computeRequestHash(UUID orderId, String providerTxId) {
+		try {
+			MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			String raw = orderId + "|" + providerTxId;
+			byte[] hashed = digest.digest(raw.getBytes(StandardCharsets.UTF_8));
+			return HexFormat.of().formatHex(hashed);
+		} catch (NoSuchAlgorithmException ex) {
+			throw new ApiException(ErrorCode.INTERNAL_ERROR, "Unable to compute idempotency hash");
+		}
+	}
+
+	private String toSnapshot(CreditPayment payment) {
+		try {
+			return objectMapper.writeValueAsString(new PaymentSnapshot(
+				payment.getId(),
+				payment.getOrderId(),
+				payment.getProviderTxId(),
+				payment.getStatus().name(),
+				payment.getCreatedAt()
+			));
+		} catch (JsonProcessingException ex) {
+			throw new ApiException(ErrorCode.INTERNAL_ERROR, "Unable to serialize idempotency response");
+		}
+	}
+
 	private void sleepIfNeeded() {
 		long delay = creditProperties.getUnsafeDelayMs();
 		if (delay <= 0) return;
@@ -62,5 +172,14 @@ public class CreditPaymentService {
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
 		}
+	}
+
+	private record PaymentSnapshot(
+		UUID paymentId,
+		UUID orderId,
+		String providerTxId,
+		String status,
+		Instant createdAt
+	) {
 	}
 }

--- a/opicer-api/src/main/java/com/opicer/api/credit/domain/CreditPaymentIdempotency.java
+++ b/opicer-api/src/main/java/com/opicer/api/credit/domain/CreditPaymentIdempotency.java
@@ -1,0 +1,114 @@
+package com.opicer.api.credit.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(
+	name = "credit_payment_idempotency",
+	uniqueConstraints = @UniqueConstraint(name = "uk_credit_payment_idempotency_user_key", columnNames = {"userId", "idempotencyKey"})
+)
+public class CreditPaymentIdempotency {
+
+	@Id
+	@GeneratedValue
+	private UUID id;
+
+	@Column(nullable = false)
+	private UUID userId;
+
+	@Column(nullable = false, length = 128)
+	private String idempotencyKey;
+
+	@Column(nullable = false, length = 64)
+	private String requestHash;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private CreditPaymentIdempotencyStatus status;
+
+	@Column
+	private UUID paymentId;
+
+	@Column
+	private Integer responseStatus;
+
+	@Lob
+	@Column
+	private String responseBody;
+
+	@Column(nullable = false)
+	private Instant expiresAt;
+
+	@Column(nullable = false)
+	private Instant createdAt;
+
+	@Column(nullable = false)
+	private Instant updatedAt;
+
+	protected CreditPaymentIdempotency() {
+	}
+
+	public CreditPaymentIdempotency(UUID userId, String idempotencyKey, String requestHash, Instant expiresAt) {
+		this.userId = userId;
+		this.idempotencyKey = idempotencyKey;
+		this.requestHash = requestHash;
+		this.status = CreditPaymentIdempotencyStatus.IN_PROGRESS;
+		this.expiresAt = expiresAt;
+	}
+
+	@PrePersist
+	void onCreate() {
+		Instant now = Instant.now();
+		this.createdAt = now;
+		this.updatedAt = now;
+	}
+
+	@PreUpdate
+	void onUpdate() {
+		this.updatedAt = Instant.now();
+	}
+
+	public UUID getId() { return id; }
+	public UUID getUserId() { return userId; }
+	public String getIdempotencyKey() { return idempotencyKey; }
+	public String getRequestHash() { return requestHash; }
+	public CreditPaymentIdempotencyStatus getStatus() { return status; }
+	public UUID getPaymentId() { return paymentId; }
+	public Integer getResponseStatus() { return responseStatus; }
+	public String getResponseBody() { return responseBody; }
+	public Instant getExpiresAt() { return expiresAt; }
+	public Instant getCreatedAt() { return createdAt; }
+	public Instant getUpdatedAt() { return updatedAt; }
+
+	public boolean isCompleted() {
+		return this.status == CreditPaymentIdempotencyStatus.COMPLETED;
+	}
+
+	public void complete(UUID paymentId, int responseStatus, String responseBody) {
+		this.paymentId = paymentId;
+		this.responseStatus = responseStatus;
+		this.responseBody = responseBody;
+		this.status = CreditPaymentIdempotencyStatus.COMPLETED;
+	}
+
+	public void refreshForNewRequest(String requestHash, Instant expiresAt) {
+		this.requestHash = requestHash;
+		this.status = CreditPaymentIdempotencyStatus.IN_PROGRESS;
+		this.paymentId = null;
+		this.responseStatus = null;
+		this.responseBody = null;
+		this.expiresAt = expiresAt;
+	}
+}

--- a/opicer-api/src/main/java/com/opicer/api/credit/domain/CreditPaymentIdempotencyStatus.java
+++ b/opicer-api/src/main/java/com/opicer/api/credit/domain/CreditPaymentIdempotencyStatus.java
@@ -1,0 +1,6 @@
+package com.opicer.api.credit.domain;
+
+public enum CreditPaymentIdempotencyStatus {
+	IN_PROGRESS,
+	COMPLETED
+}

--- a/opicer-api/src/main/java/com/opicer/api/credit/infrastructure/CreditPaymentIdempotencyRepository.java
+++ b/opicer-api/src/main/java/com/opicer/api/credit/infrastructure/CreditPaymentIdempotencyRepository.java
@@ -1,0 +1,20 @@
+package com.opicer.api.credit.infrastructure;
+
+import com.opicer.api.credit.domain.CreditPaymentIdempotency;
+import jakarta.persistence.LockModeType;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CreditPaymentIdempotencyRepository extends JpaRepository<CreditPaymentIdempotency, UUID> {
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("select i from CreditPaymentIdempotency i where i.userId = :userId and i.idempotencyKey = :key")
+	Optional<CreditPaymentIdempotency> findForUpdate(@Param("userId") UUID userId, @Param("key") String key);
+
+	int deleteByExpiresAtBefore(Instant now);
+}

--- a/opicer-api/src/main/java/com/opicer/api/credit/presentation/CreditPurchaseController.java
+++ b/opicer-api/src/main/java/com/opicer/api/credit/presentation/CreditPurchaseController.java
@@ -14,6 +14,7 @@ import java.util.UUID;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -44,9 +45,14 @@ public class CreditPurchaseController {
 
 	@PostMapping("/payments/confirm")
 	public ResponseEntity<ApiResponse<PaymentResponse>> confirmPayment(
+		@RequestHeader("Idempotency-Key") String idempotencyKey,
 		@Valid @RequestBody PaymentConfirmRequest request
 	) {
-		CreditPayment payment = creditPaymentService.confirmPayment(request.orderId(), request.providerTxId());
+		CreditPayment payment = creditPaymentService.confirmPaymentWithIdempotency(
+			request.orderId(),
+			request.providerTxId(),
+			idempotencyKey
+		);
 		if (request.simulateTimeout()) {
 			throw new org.springframework.web.server.ResponseStatusException(
 				org.springframework.http.HttpStatus.GATEWAY_TIMEOUT,

--- a/opicer-api/src/main/java/com/opicer/api/shared/error/ErrorCode.java
+++ b/opicer-api/src/main/java/com/opicer/api/shared/error/ErrorCode.java
@@ -20,7 +20,8 @@ public enum ErrorCode {
 	AI_TRANSCRIPTION_FAILED("AI_TRANSCRIPTION_FAILED", HttpStatus.BAD_GATEWAY, "Audio transcription failed"),
 	AI_ANALYSIS_FAILED("AI_ANALYSIS_FAILED", HttpStatus.BAD_GATEWAY, "AI analysis failed"),
 	AI_EMBEDDING_FAILED("AI_EMBEDDING_FAILED", HttpStatus.BAD_GATEWAY, "Embedding generation failed"),
-	AI_RAG_FAILED("AI_RAG_FAILED", HttpStatus.BAD_GATEWAY, "RAG retrieval failed");
+	AI_RAG_FAILED("AI_RAG_FAILED", HttpStatus.BAD_GATEWAY, "RAG retrieval failed"),
+	IDEMPOTENCY_KEY_CONFLICT("IDEMPOTENCY_KEY_CONFLICT", HttpStatus.CONFLICT, "Idempotency key already used with different request");
 
 	private final String code;
 	private final HttpStatus httpStatus;

--- a/opicer-api/src/main/java/com/opicer/api/shared/presentation/GlobalExceptionHandler.java
+++ b/opicer-api/src/main/java/com/opicer/api/shared/presentation/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -51,7 +52,11 @@ public class GlobalExceptionHandler {
 		return ResponseEntity.status(ErrorCode.BAD_REQUEST.getHttpStatus()).body(response);
 	}
 
-	@ExceptionHandler({MissingServletRequestParameterException.class, MissingServletRequestPartException.class})
+	@ExceptionHandler({
+		MissingServletRequestParameterException.class,
+		MissingServletRequestPartException.class,
+		MissingRequestHeaderException.class
+	})
 	public ResponseEntity<ErrorResponse> handleMissingParam(Exception ex) {
 		ErrorResponse response = ErrorResponse.from(ErrorCode.VALIDATION_ERROR,
 			ErrorCode.VALIDATION_ERROR.getDefaultMessage());

--- a/opicer-api/src/main/resources/application.yaml
+++ b/opicer-api/src/main/resources/application.yaml
@@ -56,3 +56,4 @@ opicer:
     good-answer-url-prefix: ${OPICER_GOOD_ANSWER_URL_PREFIX:/media/good-answers}
   credit:
     unsafe-delay-ms: ${OPICER_CREDIT_UNSAFE_DELAY_MS:0}
+    idempotency-ttl-hours: ${OPICER_CREDIT_IDEMPOTENCY_TTL_HOURS:24}

--- a/opicer-api/src/test/java/com/opicer/api/credit/application/CreditPaymentIdempotencyTest.java
+++ b/opicer-api/src/test/java/com/opicer/api/credit/application/CreditPaymentIdempotencyTest.java
@@ -1,0 +1,93 @@
+package com.opicer.api.credit.application;
+
+import com.opicer.api.credit.domain.CreditOrder;
+import com.opicer.api.credit.domain.CreditPayment;
+import com.opicer.api.credit.infrastructure.CreditPaymentRepository;
+import com.opicer.api.shared.error.ApiException;
+import com.opicer.api.shared.error.ErrorCode;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@TestPropertySource(properties = "opicer.credit.unsafe-delay-ms=50")
+class CreditPaymentIdempotencyTest {
+
+	@Autowired
+	private CreditOrderService creditOrderService;
+
+	@Autowired
+	private CreditPaymentService creditPaymentService;
+
+	@Autowired
+	private CreditPaymentRepository creditPaymentRepository;
+
+	@Autowired
+	private CreditBalanceService creditBalanceService;
+
+	@Test
+	void sameKeySamePayloadReturnsExistingPayment() {
+		UUID userId = UUID.randomUUID();
+		CreditOrder order = creditOrderService.createOrder(userId, "PACK_10", 10000);
+
+		CreditPayment first = creditPaymentService
+			.confirmPaymentWithIdempotency(order.getId(), "TX-IDEMPOTENT-1", "idem-key-1");
+		CreditPayment second = creditPaymentService
+			.confirmPaymentWithIdempotency(order.getId(), "TX-IDEMPOTENT-1", "idem-key-1");
+
+		assertThat(second.getId()).isEqualTo(first.getId());
+		assertThat(creditPaymentRepository.countByOrderId(order.getId())).isEqualTo(1);
+		assertThat(creditBalanceService.getBalance(order.getUserId()).getBalance()).isEqualTo(order.getAmount());
+	}
+
+	@Test
+	void sameKeyDifferentPayloadThrowsConflict() {
+		UUID userId = UUID.randomUUID();
+		CreditOrder order = creditOrderService.createOrder(userId, "PACK_10", 10000);
+
+		creditPaymentService.confirmPaymentWithIdempotency(order.getId(), "TX-FIRST", "idem-key-2");
+
+		assertThatThrownBy(() -> creditPaymentService
+			.confirmPaymentWithIdempotency(order.getId(), "TX-SECOND", "idem-key-2"))
+			.isInstanceOf(ApiException.class)
+			.satisfies(ex -> assertThat(((ApiException) ex).getErrorCode()).isEqualTo(ErrorCode.IDEMPOTENCY_KEY_CONFLICT));
+	}
+
+	@Test
+	void concurrentSameKeyCreatesSinglePaymentAndBalanceUpdate() throws Exception {
+		UUID userId = UUID.randomUUID();
+		CreditOrder order = creditOrderService.createOrder(userId, "PACK_10", 10000);
+		int threads = 20;
+		ExecutorService executor = Executors.newFixedThreadPool(threads);
+		CountDownLatch startGate = new CountDownLatch(1);
+		CountDownLatch doneGate = new CountDownLatch(threads);
+
+		for (int i = 0; i < threads; i++) {
+			executor.submit(() -> {
+				try {
+					startGate.await();
+					creditPaymentService.confirmPaymentWithIdempotency(order.getId(), "TX-SAME", "idem-key-3");
+				} catch (Exception ignored) {
+				} finally {
+					doneGate.countDown();
+				}
+			});
+		}
+
+		startGate.countDown();
+		assertThat(doneGate.await(10, TimeUnit.SECONDS)).isTrue();
+		executor.shutdown();
+
+		assertThat(creditPaymentRepository.countByOrderId(order.getId())).isEqualTo(1);
+		assertThat(creditBalanceService.getBalance(order.getUserId()).getBalance()).isEqualTo(order.getAmount());
+	}
+}

--- a/opicer-api/src/test/java/com/opicer/api/credit/application/CreditPaymentRetryTest.java
+++ b/opicer-api/src/test/java/com/opicer/api/credit/application/CreditPaymentRetryTest.java
@@ -3,13 +3,19 @@ package com.opicer.api.credit.application;
 import com.opicer.api.credit.domain.CreditOrder;
 import com.opicer.api.credit.infrastructure.CreditPaymentRepository;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
+@TestPropertySource(properties = "opicer.credit.unsafe-delay-ms=50")
 class CreditPaymentRetryTest {
 
 	@Autowired
@@ -25,15 +31,36 @@ class CreditPaymentRetryTest {
 	private CreditBalanceService creditBalanceService;
 
 	@Test
-	void retryAfterTimeoutCanDuplicatePaymentAndBalance() {
+	void retryDuringInFlightCanDuplicatePaymentAndBalance() throws Exception {
 		UUID userId = UUID.randomUUID();
 		CreditOrder order = creditOrderService.createOrder(userId, "PACK_10", 10000);
 
-		// First request succeeds but client perceives timeout (simulated at controller level in real flow).
-		creditPaymentService.confirmPayment(order.getId(), "TX-RETRY-1");
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		CountDownLatch startGate = new CountDownLatch(1);
+		CountDownLatch doneGate = new CountDownLatch(2);
 
-		// Client retries the same logical request (no idempotency key in vulnerable version).
-		creditPaymentService.confirmPayment(order.getId(), "TX-RETRY-2");
+		executor.submit(() -> {
+			try {
+				startGate.await();
+				creditPaymentService.confirmPayment(order.getId(), "TX-RETRY-1");
+			} catch (Exception ignored) {
+			} finally {
+				doneGate.countDown();
+			}
+		});
+		executor.submit(() -> {
+			try {
+				startGate.await();
+				creditPaymentService.confirmPayment(order.getId(), "TX-RETRY-2");
+			} catch (Exception ignored) {
+			} finally {
+				doneGate.countDown();
+			}
+		});
+
+		startGate.countDown();
+		assertThat(doneGate.await(10, TimeUnit.SECONDS)).isTrue();
+		executor.shutdown();
 
 		long count = creditPaymentRepository.countByOrderId(order.getId());
 		long balance = creditBalanceService.getBalance(order.getUserId()).getBalance();


### PR DESCRIPTION
## Background and Purpose
크레딧 결제 승인 API에서 Idempotency-Key 기반 중복 방지를 적용합니다.

## What changed
- `credit_payment_idempotency` 엔티티/리포지토리 추가
- `POST /api/credits/payments/confirm`에 `Idempotency-Key` 헤더 필수 적용
- 동일 키 + 동일 payload 재요청 시 기존 결제 결과 재사용
- 동일 키 + 다른 payload는 `IDEMPOTENCY_KEY_CONFLICT(409)` 반환
- 만료 정책(`opicer.credit.idempotency-ttl-hours`, 기본 24h) 추가
- 누락 헤더 예외를 `VALIDATION_ERROR`로 매핑
- idempotency 동작/동시성 테스트 추가

## How to test
- `cd opicer-api`
- `./gradlew test --tests "com.opicer.api.credit.application.*"`

## Non-goals
- Redis lock / MQ 기반 중복 방지
- 주문 생성 API idempotency 적용

## Checklist
- [x] Tests passing (`./gradlew test --tests "com.opicer.api.credit.application.*"`)
- [x] No unrelated files included
- [x] Docs updated (if needed)

Closes #59