### PR TITLE
[Feature] Add credit purchase frontend page and navigation

### DIFF
--- a/opicer-api/src/main/java/com/opicer/api/credit/application/CreditBalanceService.java
+++ b/opicer-api/src/main/java/com/opicer/api/credit/application/CreditBalanceService.java
@@ -3,11 +3,15 @@ package com.opicer.api.credit.application;
 import com.opicer.api.credit.domain.CreditBalance;
 import com.opicer.api.credit.infrastructure.CreditBalanceRepository;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class CreditBalanceService {
+
+	private static final Logger log = LoggerFactory.getLogger(CreditBalanceService.class);
 
 	private final CreditBalanceRepository creditBalanceRepository;
 
@@ -17,14 +21,17 @@ public class CreditBalanceService {
 
 	@Transactional
 	public CreditBalance ensureBalance(UUID userId) {
+		log.debug("Ensuring credit balance row exists. userId={}", userId);
 		return creditBalanceRepository.findByUserId(userId)
 			.orElseGet(() -> creditBalanceRepository.save(new CreditBalance(userId)));
 	}
 
 	@Transactional
 	public void addBalance(UUID userId, long amount) {
+		log.info("Increasing credit balance. userId={}, delta={}", userId, amount);
 		int updated = creditBalanceRepository.addBalance(userId, amount);
 		if (updated == 0) {
+			log.warn("Balance row missing during increment; creating fallback row. userId={}", userId);
 			CreditBalance created = creditBalanceRepository.save(new CreditBalance(userId));
 			created.increase(amount);
 			creditBalanceRepository.save(created);
@@ -33,6 +40,7 @@ public class CreditBalanceService {
 
 	@Transactional(readOnly = true)
 	public CreditBalance getBalance(UUID userId) {
+		log.debug("Fetching credit balance. userId={}", userId);
 		return creditBalanceRepository.findByUserId(userId)
 			.orElseThrow(() -> new IllegalArgumentException("Balance not found"));
 	}

--- a/opicer-api/src/main/java/com/opicer/api/credit/application/CreditOrderService.java
+++ b/opicer-api/src/main/java/com/opicer/api/credit/application/CreditOrderService.java
@@ -3,11 +3,15 @@ package com.opicer.api.credit.application;
 import com.opicer.api.credit.domain.CreditOrder;
 import com.opicer.api.credit.infrastructure.CreditOrderRepository;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class CreditOrderService {
+
+	private static final Logger log = LoggerFactory.getLogger(CreditOrderService.class);
 
 	private final CreditOrderRepository creditOrderRepository;
 	private final CreditBalanceService creditBalanceService;
@@ -19,13 +23,17 @@ public class CreditOrderService {
 
 	@Transactional
 	public CreditOrder createOrder(UUID userId, String packageId, int amount) {
+		log.info("Creating credit order. userId={}, packageId={}, amount={}", userId, packageId, amount);
 		creditBalanceService.ensureBalance(userId);
 		CreditOrder order = new CreditOrder(userId, packageId, amount);
-		return creditOrderRepository.save(order);
+		CreditOrder saved = creditOrderRepository.save(order);
+		log.info("Credit order created. orderId={}, userId={}, status={}", saved.getId(), userId, saved.getStatus());
+		return saved;
 	}
 
 	@Transactional(readOnly = true)
 	public CreditOrder getOrder(UUID orderId) {
+		log.debug("Fetching credit order. orderId={}", orderId);
 		return creditOrderRepository.findById(orderId)
 			.orElseThrow(() -> new IllegalArgumentException("Order not found"));
 	}

--- a/opicer-api/src/main/java/com/opicer/api/credit/application/CreditPaymentService.java
+++ b/opicer-api/src/main/java/com/opicer/api/credit/application/CreditPaymentService.java
@@ -23,11 +23,15 @@ import java.util.HexFormat;
 import java.util.UUID;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class CreditPaymentService {
+
+	private static final Logger log = LoggerFactory.getLogger(CreditPaymentService.class);
 
 	private final CreditOrderService creditOrderService;
 	private final CreditPaymentRepository creditPaymentRepository;
@@ -57,6 +61,7 @@ public class CreditPaymentService {
 
 	@Transactional
 	public CreditPayment confirmPayment(UUID orderId, String providerTxId) {
+		log.info("Confirming credit payment (vulnerable path). orderId={}, providerTxId={}", orderId, providerTxId);
 		CreditOrder order = creditOrderService.getOrder(orderId);
 		mockPaymentRecordRepository.save(new MockPaymentRecord(providerTxId, MockPaymentDecision.APPROVED));
 
@@ -70,7 +75,10 @@ public class CreditPaymentService {
 				// NOTE: INTENTIONALLY VULNERABLE
 				// Balance update can be executed multiple times if duplicate payment is created.
 				creditBalanceService.addBalance(order.getUserId(), order.getAmount());
-				return creditPaymentRepository.save(payment);
+				CreditPayment saved = creditPaymentRepository.save(payment);
+				log.info("Credit payment approved. paymentId={}, orderId={}, userId={}",
+					saved.getId(), saved.getOrderId(), order.getUserId());
+				return saved;
 			});
 	}
 
@@ -83,9 +91,12 @@ public class CreditPaymentService {
 		String requestHash = computeRequestHash(orderId, providerTxId);
 		Instant now = Instant.now();
 		Instant expiresAt = now.plus(creditProperties.getIdempotencyTtlHours(), ChronoUnit.HOURS);
+		log.info("Confirming credit payment with idempotency. orderId={}, key={}", orderId, idempotencyKey);
 		CreditPaymentIdempotency idem = acquireIdempotency(order.getUserId(), idempotencyKey, requestHash, now, expiresAt);
 
 		if (idem.isCompleted()) {
+			log.info("Reusing completed idempotent result. orderId={}, key={}, paymentId={}",
+				orderId, idempotencyKey, idem.getPaymentId());
 			return creditPaymentRepository.findById(idem.getPaymentId())
 				.orElseThrow(() -> new ApiException(ErrorCode.INTERNAL_ERROR, "Saved idempotency response is invalid"));
 		}
@@ -93,6 +104,8 @@ public class CreditPaymentService {
 		CreditPayment payment = confirmPayment(orderId, providerTxId);
 		idem.complete(payment.getId(), HttpStatus.OK.value(), toSnapshot(payment));
 		creditPaymentIdempotencyRepository.save(idem);
+		log.info("Idempotent payment confirmation completed. orderId={}, key={}, paymentId={}",
+			orderId, idempotencyKey, payment.getId());
 		return payment;
 	}
 
@@ -107,14 +120,19 @@ public class CreditPaymentService {
 			.findForUpdate(userId, idempotencyKey)
 			.orElse(null);
 		if (existing != null) {
+			log.debug("Idempotency key found. userId={}, key={}, status={}",
+				userId, idempotencyKey, existing.getStatus());
 			return validateOrReuse(existing, requestHash, now, expiresAt);
 		}
 
 		try {
 			CreditPaymentIdempotency created = creditPaymentIdempotencyRepository
 				.saveAndFlush(new CreditPaymentIdempotency(userId, idempotencyKey, requestHash, expiresAt));
+			log.debug("Idempotency key created. userId={}, key={}", userId, idempotencyKey);
 			return created;
 		} catch (DataIntegrityViolationException ex) {
+			log.debug("Idempotency unique collision occurred; retrying with lock. userId={}, key={}",
+				userId, idempotencyKey);
 			CreditPaymentIdempotency conflicted = creditPaymentIdempotencyRepository
 				.findForUpdate(userId, idempotencyKey)
 				.orElseThrow(() -> new ApiException(ErrorCode.INTERNAL_ERROR, "Failed to read idempotency key"));
@@ -129,10 +147,13 @@ public class CreditPaymentService {
 		Instant expiresAt
 	) {
 		if (existing.getExpiresAt().isBefore(now)) {
+			log.info("Idempotency key expired; refreshing. userId={}, key={}",
+				existing.getUserId(), existing.getIdempotencyKey());
 			existing.refreshForNewRequest(requestHash, expiresAt);
 			return creditPaymentIdempotencyRepository.save(existing);
 		}
 		if (!existing.getRequestHash().equals(requestHash)) {
+			log.warn("Idempotency key conflict. userId={}, key={}", existing.getUserId(), existing.getIdempotencyKey());
 			throw new ApiException(ErrorCode.IDEMPOTENCY_KEY_CONFLICT,
 				"Idempotency-Key already used with different request payload");
 		}

--- a/opicer-web/src/app/api/credits/orders/route.ts
+++ b/opicer-web/src/app/api/credits/orders/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const baseUrl = process.env.OPICER_API_BASE_URL || "http://localhost:8080";
+
+type ApiResponse<T> = {
+  status: number;
+  message: string;
+  data: T;
+};
+
+export async function POST(request: NextRequest) {
+  const payload = await request.text();
+  const res = await fetch(`${baseUrl}/api/credits/orders`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      cookie: request.headers.get("cookie") ?? "",
+    },
+    body: payload,
+  });
+
+  const bodyText = await res.text();
+  if (!bodyText) return NextResponse.json(null, { status: res.status });
+
+  const body = JSON.parse(bodyText) as ApiResponse<unknown>;
+  if (!res.ok) {
+    return NextResponse.json(body, { status: res.status });
+  }
+
+  return NextResponse.json(body.data, { status: res.status });
+}

--- a/opicer-web/src/app/api/credits/payments/confirm/route.ts
+++ b/opicer-web/src/app/api/credits/payments/confirm/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const baseUrl = process.env.OPICER_API_BASE_URL || "http://localhost:8080";
+
+type ApiResponse<T> = {
+  status: number;
+  message: string;
+  data: T;
+};
+
+export async function POST(request: NextRequest) {
+  const idempotencyKey = request.headers.get("idempotency-key") ?? "";
+  const payload = await request.text();
+  const res = await fetch(`${baseUrl}/api/credits/payments/confirm`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Idempotency-Key": idempotencyKey,
+      cookie: request.headers.get("cookie") ?? "",
+    },
+    body: payload,
+  });
+
+  const bodyText = await res.text();
+  if (!bodyText) return NextResponse.json(null, { status: res.status });
+
+  const body = JSON.parse(bodyText) as ApiResponse<unknown>;
+  if (!res.ok) {
+    return NextResponse.json(body, { status: res.status });
+  }
+
+  return NextResponse.json(body.data, { status: res.status });
+}

--- a/opicer-web/src/app/credit/page.tsx
+++ b/opicer-web/src/app/credit/page.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { ROUTES } from "@/lib/routes";
+import { logout } from "@/lib/auth-client";
+import { useAuthState } from "@/lib/use-auth-state";
+import { LoadingScreen } from "@/components/common/LoadingScreen";
+import { CreditPurchaseView } from "@/features/credit/components/CreditPurchaseView";
+
+export default function CreditPage() {
+  const auth = useAuthState();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (auth.status === "unauthenticated") {
+      router.replace(ROUTES.login);
+    }
+  }, [auth.status, router]);
+
+  if (auth.status === "loading") return <LoadingScreen />;
+  if (auth.status === "unauthenticated") return <LoadingScreen />;
+
+  const handleLogout = async () => {
+    await logout();
+    window.location.href = ROUTES.login;
+  };
+
+  return <CreditPurchaseView user={auth.user} onLogout={handleLogout} />;
+}

--- a/opicer-web/src/components/common/TopNav.tsx
+++ b/opicer-web/src/components/common/TopNav.tsx
@@ -113,6 +113,14 @@ export function TopNav({
                 >
                   마이페이지
                 </Link>
+                <Link
+                  href={ROUTES.credit}
+                  role="menuitem"
+                  onClick={() => setIsMenuOpen(false)}
+                  className="block rounded-xl px-3 py-2 text-[var(--ink)] hover:bg-[var(--accent)]/10"
+                >
+                  결제/크레딧 구매
+                </Link>
               </div>
             ) : null}
           </div>

--- a/opicer-web/src/features/credit/api.ts
+++ b/opicer-web/src/features/credit/api.ts
@@ -1,0 +1,60 @@
+import type { CreditOrderResponse, CreditPaymentResponse } from "@/features/credit/types";
+
+type ApiError = {
+  message?: string;
+};
+
+async function parseError(res: Response): Promise<string> {
+  const text = await res.text().catch(() => "");
+  if (!text) return `Request failed (${res.status})`;
+  try {
+    const body = JSON.parse(text) as ApiError;
+    return body.message ?? text;
+  } catch {
+    return text;
+  }
+}
+
+export async function createCreditOrder(input: {
+  userId: string;
+  packageId: string;
+  amount: number;
+}): Promise<CreditOrderResponse> {
+  const res = await fetch("/api/credits/orders", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+
+  if (!res.ok) {
+    throw new Error(await parseError(res));
+  }
+
+  return (await res.json()) as CreditOrderResponse;
+}
+
+export async function confirmCreditPayment(input: {
+  orderId: string;
+  providerTxId: string;
+  idempotencyKey: string;
+  simulateTimeout?: boolean;
+}): Promise<CreditPaymentResponse> {
+  const res = await fetch("/api/credits/payments/confirm", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Idempotency-Key": input.idempotencyKey,
+    },
+    body: JSON.stringify({
+      orderId: input.orderId,
+      providerTxId: input.providerTxId,
+      simulateTimeout: input.simulateTimeout ?? false,
+    }),
+  });
+
+  if (!res.ok) {
+    throw new Error(await parseError(res));
+  }
+
+  return (await res.json()) as CreditPaymentResponse;
+}

--- a/opicer-web/src/features/credit/components/CreditPurchaseView.tsx
+++ b/opicer-web/src/features/credit/components/CreditPurchaseView.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { TopNav } from "@/components/common/TopNav";
+import { createCreditOrder, confirmCreditPayment } from "@/features/credit/api";
+import { CREDIT_PACKAGES, type CreditPackage, type CreditPaymentResponse } from "@/features/credit/types";
+import type { User } from "@/types/auth";
+
+type RetryRequest = {
+  orderId: string;
+  providerTxId: string;
+  idempotencyKey: string;
+};
+
+export function CreditPurchaseView({
+  user,
+  onLogout,
+}: {
+  user: User;
+  onLogout: () => void;
+}) {
+  const [selectedPackageId, setSelectedPackageId] = useState<string>(CREDIT_PACKAGES[0].id);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [paymentResult, setPaymentResult] = useState<CreditPaymentResponse | null>(null);
+  const [lastRetryRequest, setLastRetryRequest] = useState<RetryRequest | null>(null);
+
+  const selectedPackage = useMemo<CreditPackage>(
+    () => CREDIT_PACKAGES.find((pkg) => pkg.id === selectedPackageId) ?? CREDIT_PACKAGES[0],
+    [selectedPackageId]
+  );
+
+  const handlePurchase = async () => {
+    if (isSubmitting) return;
+    setError(null);
+    setPaymentResult(null);
+    setIsSubmitting(true);
+    setLastRetryRequest(null);
+
+    try {
+      const order = await createCreditOrder({
+        userId: user.id,
+        packageId: selectedPackage.id,
+        amount: selectedPackage.amount,
+      });
+
+      const retryPayload: RetryRequest = {
+        orderId: order.orderId,
+        providerTxId: `TX-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+        idempotencyKey: crypto.randomUUID(),
+      };
+
+      setLastRetryRequest(retryPayload);
+      const payment = await confirmCreditPayment(retryPayload);
+      setPaymentResult(payment);
+      setLastRetryRequest(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "구매 처리 중 오류가 발생했습니다.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleRetry = async () => {
+    if (!lastRetryRequest || isSubmitting) return;
+    setError(null);
+    setIsSubmitting(true);
+
+    try {
+      const payment = await confirmCreditPayment(lastRetryRequest);
+      setPaymentResult(payment);
+      setLastRetryRequest(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "재시도 중 오류가 발생했습니다.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen px-6 py-10 text-[var(--ink)]">
+      <TopNav
+        userLabel={user.name ?? user.email ?? "사용자"}
+        onLogout={onLogout}
+        maxWidthClassName="max-w-5xl"
+      />
+
+      <main className="mx-auto mt-10 flex w-full max-w-5xl flex-col gap-8">
+        <section className="rounded-3xl border border-black/10 bg-white p-8 shadow-sm">
+          <p className="text-xs uppercase tracking-[0.2em] text-[var(--muted)]">Credit Purchase</p>
+          <h2 className="mt-2 text-3xl font-semibold">결제/크레딧 구매</h2>
+          <p className="mt-2 text-sm text-[var(--muted)]">
+            패키지를 선택하면 주문 생성 후 결제 확정까지 자동으로 진행됩니다.
+          </p>
+        </section>
+
+        <section className="grid gap-4 md:grid-cols-3">
+          {CREDIT_PACKAGES.map((pkg) => {
+            const selected = pkg.id === selectedPackage.id;
+            return (
+              <button
+                key={pkg.id}
+                type="button"
+                onClick={() => setSelectedPackageId(pkg.id)}
+                className={`rounded-2xl border p-5 text-left transition ${
+                  selected
+                    ? "border-[var(--accent-strong)] bg-[var(--accent)]/10"
+                    : "border-black/10 bg-white hover:border-[var(--accent)]/50"
+                }`}
+              >
+                <p className="text-xs uppercase tracking-[0.16em] text-[var(--muted)]">{pkg.id}</p>
+                <h3 className="mt-2 text-xl font-semibold">{pkg.title}</h3>
+                <p className="mt-2 text-sm text-[var(--muted)]">{pkg.description}</p>
+                <p className="mt-4 text-lg font-bold">{pkg.amount.toLocaleString()} P</p>
+              </button>
+            );
+          })}
+        </section>
+
+        <section className="rounded-2xl border border-black/10 bg-white p-6">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <p className="text-sm text-[var(--muted)]">선택된 패키지</p>
+              <p className="text-xl font-semibold">{selectedPackage.title}</p>
+              <p className="text-sm text-[var(--muted)]">{selectedPackage.amount.toLocaleString()} P</p>
+            </div>
+            <button
+              type="button"
+              onClick={handlePurchase}
+              disabled={isSubmitting}
+              className="rounded-full bg-[var(--accent-strong)] px-6 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isSubmitting ? "처리 중..." : "구매하기"}
+            </button>
+          </div>
+
+          {paymentResult ? (
+            <div className="mt-4 rounded-xl border border-emerald-300 bg-emerald-50 p-4 text-sm">
+              <p className="font-semibold text-emerald-800">결제가 완료되었습니다.</p>
+              <p className="mt-1 text-emerald-700">paymentId: {paymentResult.paymentId}</p>
+              <p className="text-emerald-700">orderId: {paymentResult.orderId}</p>
+            </div>
+          ) : null}
+
+          {error ? (
+            <div className="mt-4 rounded-xl border border-rose-300 bg-rose-50 p-4 text-sm">
+              <p className="font-semibold text-rose-800">결제 처리에 실패했습니다.</p>
+              <p className="mt-1 text-rose-700">{error}</p>
+              {lastRetryRequest ? (
+                <button
+                  type="button"
+                  onClick={handleRetry}
+                  disabled={isSubmitting}
+                  className="mt-3 rounded-full bg-rose-700 px-4 py-1.5 text-xs font-semibold text-white disabled:opacity-50"
+                >
+                  같은 요청 다시 시도
+                </button>
+              ) : null}
+            </div>
+          ) : null}
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/opicer-web/src/features/credit/components/CreditPurchaseView.tsx
+++ b/opicer-web/src/features/credit/components/CreditPurchaseView.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
 import { TopNav } from "@/components/common/TopNav";
 import { createCreditOrder, confirmCreditPayment } from "@/features/credit/api";
 import { CREDIT_PACKAGES, type CreditPackage, type CreditPaymentResponse } from "@/features/credit/types";
+import { ROUTES } from "@/lib/routes";
 import type { User } from "@/types/auth";
 
 type RetryRequest = {
@@ -19,6 +21,7 @@ export function CreditPurchaseView({
   user: User;
   onLogout: () => void;
 }) {
+  const router = useRouter();
   const [selectedPackageId, setSelectedPackageId] = useState<string>(CREDIT_PACKAGES[0].id);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -54,6 +57,7 @@ export function CreditPurchaseView({
       const payment = await confirmCreditPayment(retryPayload);
       setPaymentResult(payment);
       setLastRetryRequest(null);
+      router.replace(ROUTES.home);
     } catch (e) {
       setError(e instanceof Error ? e.message : "구매 처리 중 오류가 발생했습니다.");
     } finally {
@@ -70,6 +74,7 @@ export function CreditPurchaseView({
       const payment = await confirmCreditPayment(lastRetryRequest);
       setPaymentResult(payment);
       setLastRetryRequest(null);
+      router.replace(ROUTES.home);
     } catch (e) {
       setError(e instanceof Error ? e.message : "재시도 중 오류가 발생했습니다.");
     } finally {

--- a/opicer-web/src/features/credit/types.ts
+++ b/opicer-web/src/features/credit/types.ts
@@ -1,0 +1,29 @@
+export type CreditOrderResponse = {
+  orderId: string;
+  userId: string;
+  packageId: string;
+  amount: number;
+  status: string;
+  createdAt: string;
+};
+
+export type CreditPaymentResponse = {
+  paymentId: string;
+  orderId: string;
+  providerTxId: string;
+  status: string;
+  createdAt: string;
+};
+
+export type CreditPackage = {
+  id: string;
+  title: string;
+  amount: number;
+  description: string;
+};
+
+export const CREDIT_PACKAGES: CreditPackage[] = [
+  { id: "PACK_10", title: "Starter 10", amount: 10000, description: "빠른 연습 시작용 크레딧 패키지" },
+  { id: "PACK_30", title: "Plus 30", amount: 30000, description: "중간 강도의 반복 학습용 패키지" },
+  { id: "PACK_50", title: "Pro 50", amount: 50000, description: "장기 학습 루틴용 대용량 패키지" },
+];

--- a/opicer-web/src/lib/routes.ts
+++ b/opicer-web/src/lib/routes.ts
@@ -3,6 +3,7 @@ export const ROUTES = {
   login: "/login",
   admin: "/admin",
   mypage: "/mypage",
+  credit: "/credit",
   practice: "/practice",
   practiceSession: (topicId: string) => `/practice/${topicId}` as const,
   auth: {


### PR DESCRIPTION
## Background and Purpose
백엔드 credit 구매 API와 연동되는 프론트 구매 화면을 추가합니다.

## What changed
- 사용자 드롭다운 메뉴에 `결제/크레딧 구매` 추가
- `/credit` 전용 페이지 추가 (인증 가드 포함)
- 원클릭 구매 플로우 구현 (주문 생성 -> 결제 승인)
- 결제 승인에 `Idempotency-Key` 헤더 전달
- 결제 실패 시 동일 키로 `같은 요청 다시 시도` UX 제공
- Next API 프록시 라우트 추가
  - `POST /api/credits/orders`
  - `POST /api/credits/payments/confirm`

## How to test
1. 로그인 후 우측 사용자 드롭다운에서 `결제/크레딧 구매` 클릭
2. 패키지 선택 후 `구매하기` 클릭
3. 성공 시 paymentId/orderId 표시 확인
4. 실패 시 `같은 요청 다시 시도` 버튼으로 재시도

## Validation
- 대상 파일 eslint 통과
- 전체 `npm run lint` / `npm run build` 는 기존 코드의 선행 오류로 실패 (이번 변경과 무관)

## Non-goals
- 실결제 PG 연동
- 구매내역/잔액 조회 화면

Closes #61