### PR TITLE
[Feature] Harden credit auth and duplicate prevention

### DIFF
--- a/opicer-api/src/main/java/com/opicer/api/config/SecurityConfig.java
+++ b/opicer-api/src/main/java/com/opicer/api/config/SecurityConfig.java
@@ -40,8 +40,6 @@ public class SecurityConfig {
 		http.authorizeHttpRequests(auth -> auth
 			.requestMatchers("/h2-console/**", "/actuator/health", "/api/health").permitAll()
 			.requestMatchers("/oauth2/**", "/login/**").permitAll()
-			// Experimental credit purchase endpoints (for duplication tests)
-			.requestMatchers("/api/credits/**").permitAll()
 			.requestMatchers("/api/auth/login/**", "/api/auth/logout").permitAll()
 			.requestMatchers("/api/admin/**").hasRole("ADMIN")
 			.requestMatchers("/api/auth/me").authenticated()

--- a/opicer-api/src/main/java/com/opicer/api/credit/application/CreditPaymentService.java
+++ b/opicer-api/src/main/java/com/opicer/api/credit/application/CreditPaymentService.java
@@ -71,14 +71,20 @@ public class CreditPaymentService {
 			.orElseGet(() -> {
 				sleepIfNeeded();
 				CreditPayment payment = new CreditPayment(order.getId(), providerTxId, CreditPaymentStatus.APPROVED);
-				order.markPaid();
-				// NOTE: INTENTIONALLY VULNERABLE
-				// Balance update can be executed multiple times if duplicate payment is created.
-				creditBalanceService.addBalance(order.getUserId(), order.getAmount());
-				CreditPayment saved = creditPaymentRepository.save(payment);
-				log.info("Credit payment approved. paymentId={}, orderId={}, userId={}",
-					saved.getId(), saved.getOrderId(), order.getUserId());
-				return saved;
+				try {
+					CreditPayment saved = creditPaymentRepository.save(payment);
+					order.markPaid();
+					creditBalanceService.addBalance(order.getUserId(), order.getAmount());
+					log.info("Credit payment approved. paymentId={}, orderId={}, userId={}",
+						saved.getId(), saved.getOrderId(), order.getUserId());
+					return saved;
+				} catch (DataIntegrityViolationException ex) {
+					// DB unique constraint on orderId is the final guard for concurrent requests
+					log.warn("Duplicate payment prevented by DB unique constraint. orderId={}", orderId);
+					return creditPaymentRepository.findByOrderId(orderId)
+						.orElseThrow(() -> new ApiException(ErrorCode.DATA_INTEGRITY_VIOLATION,
+							"Duplicate payment conflict occurred"));
+				}
 			});
 	}
 

--- a/opicer-api/src/main/java/com/opicer/api/credit/domain/CreditPayment.java
+++ b/opicer-api/src/main/java/com/opicer/api/credit/domain/CreditPayment.java
@@ -8,18 +8,22 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.Instant;
 import java.util.UUID;
 
 @Entity
-@Table(name = "credit_payments")
+@Table(
+	name = "credit_payments",
+	uniqueConstraints = @UniqueConstraint(name = "uk_credit_payments_order", columnNames = {"order_id"})
+)
 public class CreditPayment {
 
 	@Id
 	@GeneratedValue
 	private UUID id;
 
-	@Column(nullable = false)
+	@Column(name = "order_id", nullable = false)
 	private UUID orderId;
 
 	@Column(nullable = false)

--- a/opicer-api/src/main/java/com/opicer/api/credit/infrastructure/CreditPaymentSchemaHardening.java
+++ b/opicer-api/src/main/java/com/opicer/api/credit/infrastructure/CreditPaymentSchemaHardening.java
@@ -1,0 +1,50 @@
+package com.opicer.api.credit.infrastructure;
+
+import java.sql.Connection;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CreditPaymentSchemaHardening implements ApplicationRunner {
+
+	private static final Logger log = LoggerFactory.getLogger(CreditPaymentSchemaHardening.class);
+
+	private final DataSource dataSource;
+	private final JdbcTemplate jdbcTemplate;
+
+	public CreditPaymentSchemaHardening(DataSource dataSource, JdbcTemplate jdbcTemplate) {
+		this.dataSource = dataSource;
+		this.jdbcTemplate = jdbcTemplate;
+	}
+
+	@Override
+	public void run(ApplicationArguments args) throws Exception {
+		try (Connection connection = dataSource.getConnection()) {
+			String databaseProductName = connection.getMetaData().getDatabaseProductName();
+			if (!"PostgreSQL".equalsIgnoreCase(databaseProductName)) {
+				return;
+			}
+		}
+
+		log.info("Ensuring unique constraint exists on credit_payments(order_id)");
+		jdbcTemplate.execute("""
+			DO $$
+			BEGIN
+			  IF NOT EXISTS (
+			    SELECT 1
+			    FROM pg_constraint
+			    WHERE conname = 'uk_credit_payments_order'
+			  ) THEN
+			    ALTER TABLE credit_payments
+			      ADD CONSTRAINT uk_credit_payments_order UNIQUE (order_id);
+			  END IF;
+			END
+			$$;
+			""");
+	}
+}

--- a/opicer-api/src/main/java/com/opicer/api/credit/presentation/CreditPurchaseController.java
+++ b/opicer-api/src/main/java/com/opicer/api/credit/presentation/CreditPurchaseController.java
@@ -4,6 +4,7 @@ import com.opicer.api.credit.application.CreditOrderService;
 import com.opicer.api.credit.application.CreditPaymentService;
 import com.opicer.api.credit.domain.CreditOrder;
 import com.opicer.api.credit.domain.CreditPayment;
+import com.opicer.api.auth.domain.AuthUserPrincipal;
 import com.opicer.api.shared.presentation.ApiResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -12,6 +13,7 @@ import jakarta.validation.constraints.Positive;
 import java.time.Instant;
 import java.util.UUID;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -35,9 +37,11 @@ public class CreditPurchaseController {
 
 	@PostMapping("/orders")
 	public ResponseEntity<ApiResponse<OrderResponse>> createOrder(
+		Authentication authentication,
 		@Valid @RequestBody OrderRequest request
 	) {
-		CreditOrder order = creditOrderService.createOrder(request.userId(), request.packageId(), request.amount());
+		UUID currentUserId = resolveCurrentUserId(authentication);
+		CreditOrder order = creditOrderService.createOrder(currentUserId, request.packageId(), request.amount());
 		return ResponseEntity.status(201).body(ApiResponse.created("CREDIT_ORDER_CREATED",
 			new OrderResponse(order.getId(), order.getUserId(), order.getPackageId(), order.getAmount(), order.getStatus().name(),
 				order.getCreatedAt())));
@@ -64,11 +68,7 @@ public class CreditPurchaseController {
 				payment.getCreatedAt())));
 	}
 
-	public record OrderRequest(
-		@NotNull UUID userId,
-		@NotBlank String packageId,
-		@Positive int amount
-	) {}
+	public record OrderRequest(@NotBlank String packageId, @Positive int amount) {}
 
 	public record OrderResponse(
 		UUID orderId,
@@ -92,4 +92,14 @@ public class CreditPurchaseController {
 		String status,
 		Instant createdAt
 	) {}
+
+	private UUID resolveCurrentUserId(Authentication authentication) {
+		if (authentication == null || !(authentication.getPrincipal() instanceof AuthUserPrincipal principal)) {
+			throw new org.springframework.web.server.ResponseStatusException(
+				org.springframework.http.HttpStatus.UNAUTHORIZED,
+				"Authentication is required"
+			);
+		}
+		return principal.id();
+	}
 }

--- a/opicer-api/src/test/java/com/opicer/api/credit/application/CreditPaymentIdempotencyTest.java
+++ b/opicer-api/src/test/java/com/opicer/api/credit/application/CreditPaymentIdempotencyTest.java
@@ -90,4 +90,38 @@ class CreditPaymentIdempotencyTest {
 		assertThat(creditPaymentRepository.countByOrderId(order.getId())).isEqualTo(1);
 		assertThat(creditBalanceService.getBalance(order.getUserId()).getBalance()).isEqualTo(order.getAmount());
 	}
+
+	@Test
+	void concurrentDifferentKeysStillCreateSinglePaymentAndBalanceUpdate() throws Exception {
+		UUID userId = UUID.randomUUID();
+		CreditOrder order = creditOrderService.createOrder(userId, "PACK_10", 10000);
+		int threads = 20;
+		ExecutorService executor = Executors.newFixedThreadPool(threads);
+		CountDownLatch startGate = new CountDownLatch(1);
+		CountDownLatch doneGate = new CountDownLatch(threads);
+
+		for (int i = 0; i < threads; i++) {
+			final int index = i;
+			executor.submit(() -> {
+				try {
+					startGate.await();
+					creditPaymentService.confirmPaymentWithIdempotency(
+						order.getId(),
+						"TX-DIFF-" + index,
+						"idem-diff-key-" + index
+					);
+				} catch (Exception ignored) {
+				} finally {
+					doneGate.countDown();
+				}
+			});
+		}
+
+		startGate.countDown();
+		assertThat(doneGate.await(10, TimeUnit.SECONDS)).isTrue();
+		executor.shutdown();
+
+		assertThat(creditPaymentRepository.countByOrderId(order.getId())).isEqualTo(1);
+		assertThat(creditBalanceService.getBalance(order.getUserId()).getBalance()).isEqualTo(order.getAmount());
+	}
 }

--- a/opicer-api/src/test/java/com/opicer/api/credit/application/CreditPaymentRetryTest.java
+++ b/opicer-api/src/test/java/com/opicer/api/credit/application/CreditPaymentRetryTest.java
@@ -31,7 +31,7 @@ class CreditPaymentRetryTest {
 	private CreditBalanceService creditBalanceService;
 
 	@Test
-	void retryDuringInFlightCanDuplicatePaymentAndBalance() throws Exception {
+	void retryDuringInFlightIsDeduplicatedByDatabaseConstraint() throws Exception {
 		UUID userId = UUID.randomUUID();
 		CreditOrder order = creditOrderService.createOrder(userId, "PACK_10", 10000);
 
@@ -65,7 +65,7 @@ class CreditPaymentRetryTest {
 		long count = creditPaymentRepository.countByOrderId(order.getId());
 		long balance = creditBalanceService.getBalance(order.getUserId()).getBalance();
 
-		assertThat(count).isGreaterThan(1);
-		assertThat(balance).isGreaterThan(order.getAmount());
+		assertThat(count).isEqualTo(1);
+		assertThat(balance).isEqualTo(order.getAmount());
 	}
 }

--- a/opicer-api/src/test/java/com/opicer/api/credit/application/CreditPaymentServiceConcurrencyTest.java
+++ b/opicer-api/src/test/java/com/opicer/api/credit/application/CreditPaymentServiceConcurrencyTest.java
@@ -31,7 +31,7 @@ class CreditPaymentServiceConcurrencyTest {
 	private com.opicer.api.credit.application.CreditBalanceService creditBalanceService;
 
 	@Test
-	void concurrentConfirmCreatesDuplicates() throws Exception {
+	void concurrentConfirmIsDeduplicatedByDatabaseConstraint() throws Exception {
 		UUID userId = UUID.randomUUID();
 		CreditOrder order = creditOrderService.createOrder(userId, "PACK_10", 10000);
 
@@ -62,9 +62,9 @@ class CreditPaymentServiceConcurrencyTest {
 		executor.shutdown();
 
 		long count = creditPaymentRepository.countByOrderId(order.getId());
-		assertThat(count).isGreaterThan(1);
+		assertThat(count).isEqualTo(1);
 
 		long balance = creditBalanceService.getBalance(order.getUserId()).getBalance();
-		assertThat(balance).isGreaterThan(order.getAmount());
+		assertThat(balance).isEqualTo(order.getAmount());
 	}
 }

--- a/opicer-api/src/test/resources/application.yaml
+++ b/opicer-api/src/test/resources/application.yaml
@@ -6,7 +6,7 @@ spring:
     password: ${OPICER_DB_PASSWORD:opicer}
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
   security:
     oauth2:
       client:

--- a/opicer-web/src/features/credit/api.ts
+++ b/opicer-web/src/features/credit/api.ts
@@ -16,7 +16,6 @@ async function parseError(res: Response): Promise<string> {
 }
 
 export async function createCreditOrder(input: {
-  userId: string;
   packageId: string;
   amount: number;
 }): Promise<CreditOrderResponse> {

--- a/opicer-web/src/features/credit/components/CreditPurchaseView.tsx
+++ b/opicer-web/src/features/credit/components/CreditPurchaseView.tsx
@@ -42,7 +42,6 @@ export function CreditPurchaseView({
 
     try {
       const order = await createCreditOrder({
-        userId: user.id,
         packageId: selectedPackage.id,
         amount: selectedPackage.amount,
       });


### PR DESCRIPTION
## Background and Purpose
credit 구매/결제 API의 인증 강제와 DB 레벨 중복 방어를 강화합니다.

## What changed
- `/api/credits/**` 접근을 인증 필수로 변경
- 주문 생성 API에서 `userId` body 제거, 인증 principal(`AuthUserPrincipal.id`)로 강제
- `credit_payments(order_id)` 유니크 제약 적용 (`uk_credit_payments_order`)
- Postgres 기동 시 유니크 제약 존재 보장 초기화 로직 추가
- 결제 저장 경합 시 DB 유니크 충돌을 잡아 기존 결제 재사용하도록 보강
- 프론트 `/credit` 주문 생성 payload에서 `userId` 제거
- credit 동시성/재시도 테스트를 중복 차단 기준으로 업데이트

## How to test
- `cd opicer-api`
- `./gradlew test --tests "com.opicer.api.credit.application.*"`
- 인증 없는 상태에서 `POST /api/credits/orders` 호출 시 401 확인
- 로그인 상태에서 `/credit` 구매 성공 확인

## Checklist
- [x] Credit backend tests passing
- [x] Changed frontend files eslint passing
- [x] No unrelated tracked files included

Closes #63