### PR TITLE
feat: RAG 메타데이터 필터 및 프롬프트 가드레일 강화

### DIFF
--- a/opicer-api/src/main/java/com/opicer/api/goodanswer/application/GoodAnswerSampleService.java
+++ b/opicer-api/src/main/java/com/opicer/api/goodanswer/application/GoodAnswerSampleService.java
@@ -79,10 +79,21 @@ public class GoodAnswerSampleService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<GoodAnswerSample> findSimilar(UUID topicId, String transcript, int limit) {
+	public List<GoodAnswerSample> findSimilar(
+		UUID topicId,
+		String transcript,
+		int limit,
+		String questionType,
+		OpicLevel targetLevel
+	) {
 		try {
 			float[] embedding = embeddingService.embed(transcript);
-			return repository.findSimilar(topicId, embedding, limit);
+			List<GoodAnswerSample> filtered = repository.findSimilar(topicId, embedding, limit, questionType, targetLevel);
+			if (!filtered.isEmpty() || (questionType == null && targetLevel == null)) {
+				return filtered;
+			}
+			// Fallback: if strict metadata filtering yields no rows, return similarity-only result.
+			return repository.findSimilar(topicId, embedding, limit, null, null);
 		} catch (ApiException e) {
 			throw e;
 		} catch (Exception e) {

--- a/opicer-api/src/main/java/com/opicer/api/goodanswer/infrastructure/GoodAnswerSampleRepositoryCustom.java
+++ b/opicer-api/src/main/java/com/opicer/api/goodanswer/infrastructure/GoodAnswerSampleRepositoryCustom.java
@@ -1,9 +1,16 @@
 package com.opicer.api.goodanswer.infrastructure;
 
 import com.opicer.api.goodanswer.domain.GoodAnswerSample;
+import com.opicer.api.shared.domain.OpicLevel;
 import java.util.List;
 import java.util.UUID;
 
 public interface GoodAnswerSampleRepositoryCustom {
-	List<GoodAnswerSample> findSimilar(UUID topicId, float[] embedding, int limit);
+	List<GoodAnswerSample> findSimilar(
+		UUID topicId,
+		float[] embedding,
+		int limit,
+		String questionType,
+		OpicLevel targetLevel
+	);
 }

--- a/opicer-api/src/main/java/com/opicer/api/goodanswer/infrastructure/GoodAnswerSampleRepositoryImpl.java
+++ b/opicer-api/src/main/java/com/opicer/api/goodanswer/infrastructure/GoodAnswerSampleRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.opicer.api.goodanswer.infrastructure;
 
 import com.opicer.api.goodanswer.domain.GoodAnswerSample;
+import com.opicer.api.shared.domain.OpicLevel;
 import com.opicer.api.shared.infrastructure.PgVectorConverter;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -17,19 +18,46 @@ public class GoodAnswerSampleRepositoryImpl implements GoodAnswerSampleRepositor
 	private EntityManager entityManager;
 
 	@Override
-	public List<GoodAnswerSample> findSimilar(UUID topicId, float[] embedding, int limit) {
+	public List<GoodAnswerSample> findSimilar(
+		UUID topicId,
+		float[] embedding,
+		int limit,
+		String questionType,
+		OpicLevel targetLevel
+	) {
 		PGobject vector = new PgVectorConverter().convertToDatabaseColumn(embedding);
-		String sql = """
+		StringBuilder sql = new StringBuilder("""
 			select *
 			from good_answer_sample
 			where topic_id = :topicId
-			order by embedding <-> :embedding
-			limit :limit
-			""";
-		Query query = entityManager.createNativeQuery(sql, GoodAnswerSample.class);
+			""");
+		if (targetLevel != null) {
+			sql.append(" and level = :targetLevel");
+		}
+		if (questionType != null && !questionType.isBlank()) {
+			sql.append("""
+				 and exists (
+				 	select 1
+				 	from good_answer_sample_tags t
+				 	where t.sample_id = good_answer_sample.id
+				 	and lower(t.tag) = lower(:questionType)
+				 )
+				""");
+		}
+		sql.append("""
+			 order by embedding <-> :embedding
+			 limit :limit
+			""");
+		Query query = entityManager.createNativeQuery(sql.toString(), GoodAnswerSample.class);
 		query.setParameter("topicId", topicId);
 		query.setParameter("embedding", vector);
 		query.setParameter("limit", limit);
+		if (targetLevel != null) {
+			query.setParameter("targetLevel", targetLevel.name());
+		}
+		if (questionType != null && !questionType.isBlank()) {
+			query.setParameter("questionType", questionType.trim());
+		}
 		@SuppressWarnings("unchecked")
 		List<GoodAnswerSample> result = query.getResultList();
 		return result;

--- a/opicer-api/src/main/java/com/opicer/api/practice/application/PracticeAiService.java
+++ b/opicer-api/src/main/java/com/opicer/api/practice/application/PracticeAiService.java
@@ -7,6 +7,7 @@ import com.opicer.api.prompt.domain.PromptUseCase;
 import com.opicer.api.prompt.domain.PromptVersion;
 import com.opicer.api.goodanswer.application.GoodAnswerSampleService;
 import com.opicer.api.goodanswer.domain.GoodAnswerSample;
+import com.opicer.api.shared.domain.OpicLevel;
 import com.opicer.api.shared.error.ApiException;
 import com.opicer.api.shared.error.ErrorCode;
 import java.io.InputStream;
@@ -85,7 +86,13 @@ public class PracticeAiService {
 		}
 	}
 
-	public String analyze(UUID topicId, String questionText, String transcript) {
+	public String analyze(
+		UUID topicId,
+		String questionText,
+		String transcript,
+		String questionType,
+		OpicLevel targetLevel
+	) {
 		String apiKey = aiProperties.getAnthropicApiKey();
 		if (apiKey == null || apiKey.isBlank()) {
 			throw new ApiException(ErrorCode.AI_NOT_CONFIGURED);
@@ -96,11 +103,17 @@ public class PracticeAiService {
 		String prompt = template
 			.replace("{questionText}", questionText)
 			.replace("{transcript}", transcript);
-		prompt = attachRagContext(prompt, topicId, transcript);
+		prompt = attachRagContext(prompt, topicId, transcript, questionType, targetLevel);
 		return callClaude(apiKey, prompt);
 	}
 
-	public String improve(UUID topicId, String questionText, String transcript) {
+	public String improve(
+		UUID topicId,
+		String questionText,
+		String transcript,
+		String questionType,
+		OpicLevel targetLevel
+	) {
 		String apiKey = aiProperties.getAnthropicApiKey();
 		if (apiKey == null || apiKey.isBlank()) {
 			throw new ApiException(ErrorCode.AI_NOT_CONFIGURED);
@@ -111,15 +124,34 @@ public class PracticeAiService {
 		String prompt = template
 			.replace("{questionText}", questionText)
 			.replace("{transcript}", transcript);
-		prompt = attachRagContext(prompt, topicId, transcript);
+		prompt = attachRagContext(prompt, topicId, transcript, questionType, targetLevel);
 		return callClaude(apiKey, prompt);
 	}
 
-	private String attachRagContext(String prompt, UUID topicId, String transcript) {
-		List<GoodAnswerSample> samples = goodAnswerSampleService.findSimilar(topicId, transcript, 3);
+	private String attachRagContext(
+		String prompt,
+		UUID topicId,
+		String transcript,
+		String questionType,
+		OpicLevel targetLevel
+	) {
+		List<GoodAnswerSample> samples = goodAnswerSampleService.findSimilar(
+			topicId,
+			transcript,
+			3,
+			questionType,
+			targetLevel
+		);
 		if (samples.isEmpty()) return prompt;
 		StringJoiner joiner = new StringJoiner("\n\n");
-		joiner.add("### Similar Good Answer Samples");
+		joiner.add("### RAG Reference Samples");
+		joiner.add("""
+			Use these references only as guidance.
+			- Do not copy sentences verbatim.
+			- Rebuild the answer in the learner's own words and context.
+			- Prioritize structure, flow, and expressions over memorization.
+			- If references conflict with learner context, prefer learner context.
+			""");
 		for (int i = 0; i < samples.size(); i++) {
 			GoodAnswerSample sample = samples.get(i);
 			joiner.add(String.format(
@@ -131,6 +163,12 @@ public class PracticeAiService {
 				sample.getSampleText()
 			));
 		}
+		joiner.add("""
+			### Output Guardrails
+			- Never output exact copied chunks from references.
+			- Keep response grounded to the given question.
+			- Keep explanation in Korean.
+			""");
 		return prompt + "\n\n" + joiner;
 	}
 

--- a/opicer-api/src/main/java/com/opicer/api/practice/presentation/PracticeAiController.java
+++ b/opicer-api/src/main/java/com/opicer/api/practice/presentation/PracticeAiController.java
@@ -1,6 +1,7 @@
 package com.opicer.api.practice.presentation;
 
 import com.opicer.api.practice.application.PracticeAiService;
+import com.opicer.api.shared.domain.OpicLevel;
 import com.opicer.api.shared.presentation.ApiResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -39,7 +40,9 @@ public class PracticeAiController {
 		String analysis = practiceAiService.analyze(
 			request.topicId(),
 			request.questionText(),
-			request.transcript()
+			request.transcript(),
+			request.questionType(),
+			request.targetLevel()
 		);
 		return ApiResponse.ok("Analysis complete", Map.of("analysis", analysis));
 	}
@@ -49,7 +52,9 @@ public class PracticeAiController {
 		String improved = practiceAiService.improve(
 			request.topicId(),
 			request.questionText(),
-			request.transcript()
+			request.transcript(),
+			request.questionType(),
+			request.targetLevel()
 		);
 		return ApiResponse.ok("Improvement complete", Map.of("improved", improved));
 	}
@@ -57,12 +62,16 @@ public class PracticeAiController {
 	record AnalyzeRequest(
 		@NotNull java.util.UUID topicId,
 		@NotBlank String questionText,
-		@NotBlank String transcript
+		@NotBlank String transcript,
+		String questionType,
+		OpicLevel targetLevel
 	) {}
 
 	record ImproveRequest(
 		@NotNull java.util.UUID topicId,
 		@NotBlank String questionText,
-		@NotBlank String transcript
+		@NotBlank String transcript,
+		String questionType,
+		OpicLevel targetLevel
 	) {}
 }

--- a/opicer-api/src/test/java/com/opicer/api/practice/presentation/PracticeAiControllerTest.java
+++ b/opicer-api/src/test/java/com/opicer/api/practice/presentation/PracticeAiControllerTest.java
@@ -108,7 +108,7 @@ class PracticeAiControllerTest {
 	// T4: POST /analyze valid JSON + auth → 200
 	@Test
 	void analyze_validRequest_returns200() throws Exception {
-		when(practiceAiService.analyze(any(), anyString(), anyString())).thenReturn("Analysis result");
+		when(practiceAiService.analyze(any(), anyString(), anyString(), any(), any())).thenReturn("Analysis result");
 
 		mockMvc.perform(post("/api/practice/analyze")
 				.contentType(MediaType.APPLICATION_JSON)
@@ -140,7 +140,7 @@ class PracticeAiControllerTest {
 	// T7: POST /improve valid JSON + auth → 200
 	@Test
 	void improve_validRequest_returns200() throws Exception {
-		when(practiceAiService.improve(any(), anyString(), anyString())).thenReturn("Improved script");
+		when(practiceAiService.improve(any(), anyString(), anyString(), any(), any())).thenReturn("Improved script");
 
 		mockMvc.perform(post("/api/practice/improve")
 				.contentType(MediaType.APPLICATION_JSON)

--- a/opicer-web/src/features/practice/api.ts
+++ b/opicer-web/src/features/practice/api.ts
@@ -69,12 +69,14 @@ export async function transcribeAudio(
 export async function analyzeAnswer(
   topicId: string,
   questionText: string,
-  transcript: string
+  transcript: string,
+  questionType?: string,
+  targetLevel?: string
 ): Promise<string> {
   const res = await fetch("/api/practice/analyze", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ topicId, questionText, transcript }),
+    body: JSON.stringify({ topicId, questionText, transcript, questionType, targetLevel }),
   });
   if (!res.ok) {
     const body = await res.json().catch(() => null);
@@ -87,12 +89,14 @@ export async function analyzeAnswer(
 export async function improveScript(
   topicId: string,
   questionText: string,
-  transcript: string
+  transcript: string,
+  questionType?: string,
+  targetLevel?: string
 ): Promise<string> {
   const res = await fetch("/api/practice/improve", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ topicId, questionText, transcript }),
+    body: JSON.stringify({ topicId, questionText, transcript, questionType, targetLevel }),
   });
   if (!res.ok) {
     const body = await res.json().catch(() => null);

--- a/opicer-web/src/features/practice/components/PracticeSessionView.tsx
+++ b/opicer-web/src/features/practice/components/PracticeSessionView.tsx
@@ -344,6 +344,9 @@ export function PracticeSessionView({ topicId, userLabel, onLogout }: Props) {
       isImproving: false, improvement: null, improveError: null,
     };
 
+  const findQuestionMeta = (questionId: string) =>
+    questions.find((q) => q.id === questionId);
+
   const handleAnalyze = async (answer: PracticeAnswer) => {
     if (!answer.transcript) return;
     const id = answer.questionId;
@@ -352,7 +355,14 @@ export function PracticeSessionView({ topicId, userLabel, onLogout }: Props) {
       [id]: { ...getOrInitAiState(id), isAnalyzing: true, analyzeError: null },
     }));
     try {
-      const analysis = await analyzeAnswer(topicId, answer.questionText, answer.transcript);
+      const question = findQuestionMeta(answer.questionId);
+      const analysis = await analyzeAnswer(
+        topicId,
+        answer.questionText,
+        answer.transcript,
+        question?.type,
+        question?.targetLevels?.[0]
+      );
       setAiStates((prev) => ({
         ...prev,
         [id]: { ...prev[id]!, isAnalyzing: false, analysis },
@@ -374,7 +384,14 @@ export function PracticeSessionView({ topicId, userLabel, onLogout }: Props) {
       [id]: { ...getOrInitAiState(id), isImproving: true, improveError: null },
     }));
     try {
-      const improvement = await improveScript(topicId, answer.questionText, answer.transcript);
+      const question = findQuestionMeta(answer.questionId);
+      const improvement = await improveScript(
+        topicId,
+        answer.questionText,
+        answer.transcript,
+        question?.type,
+        question?.targetLevels?.[0]
+      );
       setAiStates((prev) => ({
         ...prev,
         [id]: { ...prev[id]!, isImproving: false, improvement },


### PR DESCRIPTION
## Summary
- RAG 검색에 `questionType`(tag), `targetLevel` 메타데이터 필터 추가
- 필터 결과 0건 시 유사도 검색 fallback 추가
- 분석/개선 프롬프트에 참조 샘플 사용 가드레일(복붙 금지, 맥락 우선) 고정 주입
- 프론트에서 AI API 호출 시 질문 메타데이터 전달

## Commits
1. `feat(goodanswer): add metadata-aware rag retrieval`
2. `feat(practice): apply rag prompt guardrails and metadata params`
3. `feat(practice-web): send question metadata to ai endpoints`

## Test
- `./gradlew test --tests com.opicer.api.practice.presentation.PracticeAiControllerTest`

Closes #65