### PR TITLE
feat: 주제별 연습 3카테고리 개편 및 설문 체크 UX

### DIFF
--- a/opicer-api/src/main/java/com/opicer/api/topic/infrastructure/PracticeTopicBootstrapRunner.java
+++ b/opicer-api/src/main/java/com/opicer/api/topic/infrastructure/PracticeTopicBootstrapRunner.java
@@ -1,0 +1,156 @@
+package com.opicer.api.topic.infrastructure;
+
+import com.opicer.api.question.domain.Question;
+import com.opicer.api.question.domain.QuestionType;
+import com.opicer.api.question.infrastructure.QuestionRepository;
+import com.opicer.api.shared.domain.OpicLevel;
+import com.opicer.api.topic.domain.Topic;
+import com.opicer.api.topic.domain.TopicBadge;
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class PracticeTopicBootstrapRunner implements ApplicationRunner {
+
+	private static final Logger log = LoggerFactory.getLogger(PracticeTopicBootstrapRunner.class);
+
+	private static final String CATEGORY_SELF_INTRO = "자기소개";
+	private static final String CATEGORY_SURVEY = "설문조사";
+	private static final String CATEGORY_UNEXPECTED = "돌발질문";
+	private static final String LEGACY_UNEXPECTED = "돌발/상황 대처";
+	private static final String SELF_INTRO_TOPIC_TITLE = "자기소개";
+
+	private final TopicRepository topicRepository;
+	private final QuestionRepository questionRepository;
+
+	public PracticeTopicBootstrapRunner(
+		TopicRepository topicRepository,
+		QuestionRepository questionRepository
+	) {
+		this.topicRepository = topicRepository;
+		this.questionRepository = questionRepository;
+	}
+
+	@Override
+	@Transactional
+	public void run(ApplicationArguments args) {
+		reclassifyCategories();
+		ensureSelfIntroductionTopicAndQuestions();
+	}
+
+	private void reclassifyCategories() {
+		List<Topic> topics = topicRepository.findAll();
+		int updated = 0;
+		for (Topic topic : topics) {
+			String newCategory = resolveCategory(topic);
+			int newCategoryOrder = resolveCategoryOrder(newCategory);
+			if (topic.getCategory().equals(newCategory) && topic.getCategoryOrder() == newCategoryOrder) {
+				continue;
+			}
+			topic.update(
+				topic.getTitle(),
+				topic.getEnglishTitle(),
+				newCategory,
+				newCategoryOrder,
+				topic.getTopicOrder(),
+				topic.getBadges(),
+				topic.isActive()
+			);
+			topicRepository.save(topic);
+			updated++;
+		}
+		if (updated > 0) {
+			log.info("Practice category reclassified: {} topics updated", updated);
+		}
+	}
+
+	private void ensureSelfIntroductionTopicAndQuestions() {
+		Optional<Topic> existing = topicRepository.findByTitle(SELF_INTRO_TOPIC_TITLE);
+		Topic selfIntro = existing.orElseGet(() -> topicRepository.save(new Topic(
+			SELF_INTRO_TOPIC_TITLE,
+			"Self Introduction",
+			CATEGORY_SELF_INTRO,
+			0,
+			0,
+			List.of(new TopicBadge("필수", null)),
+			true
+		)));
+
+		if (existing.isEmpty()) {
+			log.info("Self-introduction topic created: {}", selfIntro.getId());
+		}
+
+		List<Question> existingQuestions = questionRepository.findByActiveTrueAndTopicOrderByCreatedAtAscIdAsc(
+			SELF_INTRO_TOPIC_TITLE
+		);
+		if (!existingQuestions.isEmpty()) {
+			return;
+		}
+
+		List<OpicLevel> baseLevels = List.of(OpicLevel.IL, OpicLevel.IM, OpicLevel.IH);
+		questionRepository.saveAll(List.of(
+			new Question(
+				SELF_INTRO_TOPIC_TITLE,
+				QuestionType.DESCRIPTION,
+				"Please introduce yourself. Tell me your name, what you do, and what your daily life is like.",
+				null,
+				"이름/역할 소개 → 평소 일상 → 최근 집중하는 것 순서로 답변하세요.",
+				baseLevels,
+				List.of("Let me introduce myself", "These days", "In my daily routine")
+			),
+			new Question(
+				SELF_INTRO_TOPIC_TITLE,
+				QuestionType.PAST_EXPERIENCE,
+				"Tell me about a recent moment that made you proud of yourself. What happened and why was it meaningful?",
+				null,
+				"상황 설명 → 내가 한 행동 → 결과/느낀 점 순서로 말하세요.",
+				baseLevels,
+				List.of("Recently", "What I did was", "It was meaningful because")
+			),
+			new Question(
+				SELF_INTRO_TOPIC_TITLE,
+				QuestionType.COMPARE_CONTRAST,
+				"Compare your current life with your life one or two years ago. What changed the most?",
+				null,
+				"과거와 현재를 비교하고, 바뀐 이유와 영향을 함께 설명하세요.",
+				baseLevels,
+				List.of("Compared to", "The biggest change is", "As a result")
+			),
+			new Question(
+				SELF_INTRO_TOPIC_TITLE,
+				QuestionType.OPINION,
+				"What personal strength helps you most in your daily life, and why do you think so?",
+				null,
+				"강점 제시 → 실제 사례 → 결론 구조로 답변하세요.",
+				baseLevels,
+				List.of("I believe my strength is", "For example", "That is why")
+			)
+		));
+		log.info("Self-introduction questions seeded");
+	}
+
+	private String resolveCategory(Topic topic) {
+		if (SELF_INTRO_TOPIC_TITLE.equals(topic.getTitle())) {
+			return CATEGORY_SELF_INTRO;
+		}
+		if (LEGACY_UNEXPECTED.equals(topic.getCategory()) || CATEGORY_UNEXPECTED.equals(topic.getCategory())) {
+			return CATEGORY_UNEXPECTED;
+		}
+		return CATEGORY_SURVEY;
+	}
+
+	private int resolveCategoryOrder(String category) {
+		return switch (category) {
+			case CATEGORY_SELF_INTRO -> 0;
+			case CATEGORY_SURVEY -> 1;
+			case CATEGORY_UNEXPECTED -> 2;
+			default -> 9;
+		};
+	}
+}

--- a/opicer-api/src/main/java/com/opicer/api/topic/infrastructure/PracticeTopicBootstrapRunner.java
+++ b/opicer-api/src/main/java/com/opicer/api/topic/infrastructure/PracticeTopicBootstrapRunner.java
@@ -72,17 +72,29 @@ public class PracticeTopicBootstrapRunner implements ApplicationRunner {
 
 	private void ensureSelfIntroductionTopicAndQuestions() {
 		Optional<Topic> existing = topicRepository.findByTitle(SELF_INTRO_TOPIC_TITLE);
-		Topic selfIntro = existing.orElseGet(() -> topicRepository.save(new Topic(
-			SELF_INTRO_TOPIC_TITLE,
-			"Self Introduction",
-			CATEGORY_SELF_INTRO,
-			0,
-			0,
-			List.of(new TopicBadge("필수", null)),
-			true
-		)));
-
-		if (existing.isEmpty()) {
+		Topic selfIntro;
+		if (existing.isPresent()) {
+			Topic topic = existing.get();
+			topic.update(
+				SELF_INTRO_TOPIC_TITLE,
+				"Self Introduction",
+				CATEGORY_SELF_INTRO,
+				0,
+				0,
+				List.of(new TopicBadge("필수", null)),
+				true
+			);
+			selfIntro = topicRepository.save(topic);
+		} else {
+			selfIntro = topicRepository.save(new Topic(
+				SELF_INTRO_TOPIC_TITLE,
+				"Self Introduction",
+				CATEGORY_SELF_INTRO,
+				0,
+				0,
+				List.of(new TopicBadge("필수", null)),
+				true
+			));
 			log.info("Self-introduction topic created: {}", selfIntro.getId());
 		}
 

--- a/opicer-api/src/main/java/com/opicer/api/topic/infrastructure/TopicRepository.java
+++ b/opicer-api/src/main/java/com/opicer/api/topic/infrastructure/TopicRepository.java
@@ -2,9 +2,11 @@ package com.opicer.api.topic.infrastructure;
 
 import com.opicer.api.topic.domain.Topic;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TopicRepository extends JpaRepository<Topic, UUID> {
 	List<Topic> findByActiveTrueOrderByCategoryOrderAscTopicOrderAscIdAsc();
+	Optional<Topic> findByTitle(String title);
 }

--- a/opicer-api/src/test/java/com/opicer/api/topic/infrastructure/PracticeTopicBootstrapRunnerTest.java
+++ b/opicer-api/src/test/java/com/opicer/api/topic/infrastructure/PracticeTopicBootstrapRunnerTest.java
@@ -1,0 +1,104 @@
+package com.opicer.api.topic.infrastructure;
+
+import com.opicer.api.question.domain.Question;
+import com.opicer.api.question.infrastructure.QuestionRepository;
+import com.opicer.api.topic.domain.Topic;
+import com.opicer.api.topic.domain.TopicBadge;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.DefaultApplicationArguments;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PracticeTopicBootstrapRunnerTest {
+
+	@Mock
+	private TopicRepository topicRepository;
+
+	@Mock
+	private QuestionRepository questionRepository;
+
+	@InjectMocks
+	private PracticeTopicBootstrapRunner runner;
+
+	@Test
+	void run_reclassifiesLegacyCategories_andSeedsSelfIntro() throws Exception {
+		Topic surveyTopic = new Topic(
+			"음악 감상",
+			"Music",
+			"여가/일상",
+			1,
+			0,
+			List.of(new TopicBadge("빈출", null)),
+			true
+		);
+		Topic unexpectedTopic = new Topic(
+			"물건 분실",
+			"Lost Item",
+			"돌발/상황 대처",
+			5,
+			1,
+			List.of(new TopicBadge("돌발 빈출", null)),
+			true
+		);
+
+		when(topicRepository.findAll()).thenReturn(List.of(surveyTopic, unexpectedTopic));
+		when(topicRepository.findByTitle("자기소개")).thenReturn(Optional.empty());
+		when(topicRepository.save(any(Topic.class))).thenAnswer(invocation -> invocation.getArgument(0));
+		when(questionRepository.findByActiveTrueAndTopicOrderByCreatedAtAscIdAsc("자기소개"))
+			.thenReturn(List.of());
+
+		runner.run(new DefaultApplicationArguments(new String[] {}));
+
+		assertThat(surveyTopic.getCategory()).isEqualTo("설문조사");
+		assertThat(surveyTopic.getCategoryOrder()).isEqualTo(1);
+		assertThat(unexpectedTopic.getCategory()).isEqualTo("돌발질문");
+		assertThat(unexpectedTopic.getCategoryOrder()).isEqualTo(2);
+		verify(questionRepository, times(1)).saveAll(any());
+	}
+
+	@Test
+	void run_skipsQuestionSeeding_whenSelfIntroQuestionsAlreadyExist() throws Exception {
+		Topic selfIntro = new Topic(
+			"자기소개",
+			"Self Introduction",
+			"자기소개",
+			0,
+			0,
+			List.of(new TopicBadge("필수", null)),
+			true
+		);
+		Topic unexpectedTopic = new Topic(
+			"약속 취소",
+			"Cancelled Plans",
+			"돌발질문",
+			2,
+			0,
+			List.of(new TopicBadge("돌발 빈출", null)),
+			true
+		);
+
+		when(topicRepository.findAll()).thenReturn(List.of(selfIntro, unexpectedTopic));
+		when(topicRepository.findByTitle("자기소개")).thenReturn(Optional.of(selfIntro));
+		when(questionRepository.findByActiveTrueAndTopicOrderByCreatedAtAscIdAsc("자기소개"))
+			.thenReturn(List.of(mock(Question.class)));
+
+		runner.run(new DefaultApplicationArguments(new String[] {}));
+
+		verify(questionRepository, never()).saveAll(any());
+		verify(topicRepository, never()).save(eq(selfIntro));
+	}
+}

--- a/opicer-api/src/test/java/com/opicer/api/topic/infrastructure/PracticeTopicBootstrapRunnerTest.java
+++ b/opicer-api/src/test/java/com/opicer/api/topic/infrastructure/PracticeTopicBootstrapRunnerTest.java
@@ -99,6 +99,8 @@ class PracticeTopicBootstrapRunnerTest {
 		runner.run(new DefaultApplicationArguments(new String[] {}));
 
 		verify(questionRepository, never()).saveAll(any());
-		verify(topicRepository, never()).save(eq(selfIntro));
+		verify(topicRepository, times(1)).save(eq(selfIntro));
+		assertThat(selfIntro.getCategory()).isEqualTo("자기소개");
+		assertThat(selfIntro.isActive()).isTrue();
 	}
 }

--- a/opicer-web/src/features/practice/components/TopicPracticeView.tsx
+++ b/opicer-web/src/features/practice/components/TopicPracticeView.tsx
@@ -57,7 +57,6 @@ export function TopicPracticeView({ userLabel, onLogout }: Props) {
 
   const [topics, setTopics] = useState<TopicItem[]>([]);
   const [activeCategoryId, setActiveCategoryId] = useState<string | null>(null);
-  const [surveyCheckedIds, setSurveyCheckedIds] = useState<string[]>([]);
   const [query, setQuery] = useState("");
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -115,18 +114,14 @@ export function TopicPracticeView({ userLabel, onLogout }: Props) {
 
   const filteredTopics = useMemo(() => {
     const base = activeCategory?.topics ?? [];
-    const surveyFiltered =
-      activeCategoryId === CATEGORY_SURVEY && surveyCheckedIds.length > 0
-        ? base.filter((topic) => surveyCheckedIds.includes(topic.id))
-        : base;
     const trimmed = query.trim().toLowerCase();
-    if (!trimmed) return surveyFiltered;
-    return surveyFiltered.filter(
+    if (!trimmed) return base;
+    return base.filter(
       (topic) =>
         topic.title.toLowerCase().includes(trimmed) ||
         topic.englishTitle.toLowerCase().includes(trimmed)
     );
-  }, [activeCategory, activeCategoryId, query, surveyCheckedIds]);
+  }, [activeCategory, query]);
 
   const groupedSurveyTopics = useMemo(() => {
     if (activeCategoryId !== CATEGORY_SURVEY) return [];
@@ -149,12 +144,6 @@ export function TopicPracticeView({ userLabel, onLogout }: Props) {
   const handleSelect = (topic: TopicItem) => {
     setError(null);
     setSelectedId((prev) => (prev === topic.id ? null : topic.id));
-  };
-
-  const toggleSurveyCheck = (topicId: string) => {
-    setSurveyCheckedIds((prev) =>
-      prev.includes(topicId) ? prev.filter((id) => id !== topicId) : [...prev, topicId]
-    );
   };
 
   const handleSubmit = async () => {
@@ -285,9 +274,6 @@ export function TopicPracticeView({ userLabel, onLogout }: Props) {
                       onClick={() => {
                         setActiveCategoryId(category.id);
                         setQuery("");
-                        if (category.id !== CATEGORY_SURVEY) {
-                          setSurveyCheckedIds([]);
-                        }
                       }}
                       className={`rounded-2xl border px-4 py-3 text-left transition ${
                         isActive
@@ -314,11 +300,6 @@ export function TopicPracticeView({ userLabel, onLogout }: Props) {
               <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--muted)]">
                 선택된 주제
               </p>
-              {activeCategoryId === CATEGORY_SURVEY ? (
-                <p className="mt-2 text-xs text-[var(--muted)]">
-                  체크한 설문 항목: {surveyCheckedIds.length}개
-                </p>
-              ) : null}
               {selectedTopic ? (
                 <div className="mt-4 rounded-2xl border border-[var(--accent)]/30 bg-[var(--accent)]/10 p-4">
                   <p className="text-sm font-semibold">{selectedTopic.title}</p>
@@ -383,7 +364,6 @@ export function TopicPracticeView({ userLabel, onLogout }: Props) {
                     <div className="grid gap-4 sm:grid-cols-2">
                       {items.map((topic) => {
                         const isSelected = selectedId === topic.id;
-                        const isChecked = surveyCheckedIds.includes(topic.id);
                         return (
                           <button
                             key={topic.id}
@@ -408,25 +388,22 @@ export function TopicPracticeView({ userLabel, onLogout }: Props) {
                                 {isSelected ? "선택됨" : "선택"}
                               </span>
                             </div>
-                            <label
-                              className={`mt-3 flex items-center gap-2 text-xs font-semibold ${
-                                isSelected ? "text-white" : "text-[var(--accent-strong)]"
-                              }`}
-                              onClick={(event) => {
-                                event.stopPropagation();
-                              }}
-                            >
-                              <input
-                                type="checkbox"
-                                checked={isChecked}
-                                onChange={(event) => {
-                                  event.stopPropagation();
-                                  toggleSurveyCheck(topic.id);
-                                }}
-                                className="h-4 w-4 accent-[var(--accent)]"
-                              />
-                              설문 항목 체크
-                            </label>
+                            {topic.badges && topic.badges.length > 0 ? (
+                              <div className="mt-3 flex flex-wrap gap-2">
+                                {topic.badges.map((badge) => (
+                                  <span
+                                    key={`${topic.id}-${badge.label}`}
+                                    className={`rounded-full border px-2.5 py-1 text-[10px] font-semibold ${
+                                      isSelected
+                                        ? "border-white/30 text-white/90"
+                                        : "border-[var(--accent)]/20 text-[var(--accent-strong)]"
+                                    }`}
+                                  >
+                                    {badge.label}{badge.count != null ? ` ${badge.count}` : ""}
+                                  </span>
+                                ))}
+                              </div>
+                            ) : null}
                           </button>
                         );
                       })}

--- a/opicer-web/src/features/practice/components/TopicPracticeView.tsx
+++ b/opicer-web/src/features/practice/components/TopicPracticeView.tsx
@@ -10,20 +10,54 @@ type Props = {
   onLogout?: () => void;
 };
 
+const CATEGORY_SELF_INTRO = "자기소개";
+const CATEGORY_SURVEY = "설문조사";
+const CATEGORY_UNEXPECTED = "돌발질문";
+
 const CATEGORY_META: Record<string, string> = {
-  "프로필/배경": "서베이 기본 정보",
-  "여가/일상": "취미와 일상 활동",
-  "취미/관심사": "개인 취미 중심",
-  "운동/건강": "운동 관련 경험",
-  "여행/출장": "이동과 휴가 경험",
-  "돌발/상황 대처": "돌발 주제 빈출",
+  [CATEGORY_SELF_INTRO]: "시험 시작 전 필수 자기소개 대비",
+  [CATEGORY_SURVEY]: "Background Survey 기반 주제",
+  [CATEGORY_UNEXPECTED]: "돌발/상황형 질문 대비",
 };
+
+const LEGACY_UNEXPECTED = new Set(["돌발/상황 대처", CATEGORY_UNEXPECTED]);
+
+const INTRO_KEYWORDS = ["자기소개", "self introduction"];
+
+const SURVEY_GROUPS: Array<{ label: string; keywords: string[] }> = [
+  { label: "거주/생활", keywords: ["집", "주거", "동네", "이웃", "기숙사", "룸메이트", "가족"] },
+  { label: "직업/학업", keywords: ["직업", "회사", "사업", "재택", "학생", "수업", "학위", "교사"] },
+  { label: "여가/취미", keywords: ["음악", "영화", "tv", "독서", "쇼핑", "요리", "공연", "콘서트", "캠핑"] },
+  { label: "운동/건강", keywords: ["운동", "헬스", "수영", "자전거", "조깅", "걷기", "요가"] },
+  { label: "여행/이동", keywords: ["여행", "출장", "휴가", "해외", "국내", "드라이브"] },
+];
+
+function resolvePrimaryCategory(topic: TopicItem): string {
+  const title = topic.title.toLowerCase();
+  if (INTRO_KEYWORDS.some((keyword) => title.includes(keyword))) return CATEGORY_SELF_INTRO;
+  if (LEGACY_UNEXPECTED.has(topic.category)) return CATEGORY_UNEXPECTED;
+  return CATEGORY_SURVEY;
+}
+
+function resolveSurveyGroup(topic: TopicItem): string {
+  const title = topic.title.toLowerCase();
+  const englishTitle = topic.englishTitle.toLowerCase();
+  const fromBadge = topic.badges?.[0]?.label?.trim();
+  if (fromBadge && fromBadge.length > 0) return fromBadge;
+  const matched = SURVEY_GROUPS.find((group) =>
+    group.keywords.some(
+      (keyword) => title.includes(keyword.toLowerCase()) || englishTitle.includes(keyword.toLowerCase())
+    )
+  );
+  return matched?.label ?? "기타";
+}
 
 export function TopicPracticeView({ userLabel, onLogout }: Props) {
   const router = useRouter();
 
   const [topics, setTopics] = useState<TopicItem[]>([]);
   const [activeCategoryId, setActiveCategoryId] = useState<string | null>(null);
+  const [surveyCheckedIds, setSurveyCheckedIds] = useState<string[]>([]);
   const [query, setQuery] = useState("");
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -38,10 +72,12 @@ export function TopicPracticeView({ userLabel, onLogout }: Props) {
       .then((data) => {
         if (!mounted) return;
         setTopics(data);
-        const firstCategory = data
-          .sort((a, b) => a.categoryOrder - b.categoryOrder)
-          .map((topic) => topic.category)[0];
-        setActiveCategoryId(firstCategory ?? null);
+        const primarySet = new Set(data.map(resolvePrimaryCategory));
+        const firstCategory =
+          [CATEGORY_SELF_INTRO, CATEGORY_SURVEY, CATEGORY_UNEXPECTED].find((category) =>
+            primarySet.has(category)
+          ) ?? CATEGORY_SURVEY;
+        setActiveCategoryId(firstCategory);
       })
       .catch((err) => {
         if (!mounted) return;
@@ -55,23 +91,20 @@ export function TopicPracticeView({ userLabel, onLogout }: Props) {
 
   const categories = useMemo<TopicCategory[]>(() => {
     const grouped = new Map<string, TopicItem[]>();
-    const categoryOrderMap = new Map<string, number>();
     topics.forEach((topic) => {
-      if (!grouped.has(topic.category)) {
-        grouped.set(topic.category, []);
-        categoryOrderMap.set(topic.category, topic.categoryOrder);
-      }
-      grouped.get(topic.category)?.push(topic);
+      const category = resolvePrimaryCategory(topic);
+      if (!grouped.has(category)) grouped.set(category, []);
+      grouped.get(category)?.push(topic);
     });
-    return Array.from(grouped.entries())
-      .map(([category, items]) => ({
+    return [CATEGORY_SELF_INTRO, CATEGORY_SURVEY, CATEGORY_UNEXPECTED]
+      .filter((category) => grouped.has(category))
+      .map((category, index) => ({
         id: category,
         label: category,
         description: CATEGORY_META[category] ?? "주제별 연습",
-        topics: items.sort((a, b) => a.topicOrder - b.topicOrder),
-        order: categoryOrderMap.get(category) ?? 0,
+        topics: (grouped.get(category) ?? []).sort((a, b) => a.topicOrder - b.topicOrder),
+        order: index,
       }))
-      .sort((a, b) => a.order - b.order)
       .map(({ order, ...rest }) => rest);
   }, [topics]);
 
@@ -82,14 +115,31 @@ export function TopicPracticeView({ userLabel, onLogout }: Props) {
 
   const filteredTopics = useMemo(() => {
     const base = activeCategory?.topics ?? [];
+    const surveyFiltered =
+      activeCategoryId === CATEGORY_SURVEY && surveyCheckedIds.length > 0
+        ? base.filter((topic) => surveyCheckedIds.includes(topic.id))
+        : base;
     const trimmed = query.trim().toLowerCase();
-    if (!trimmed) return base;
-    return base.filter(
+    if (!trimmed) return surveyFiltered;
+    return surveyFiltered.filter(
       (topic) =>
         topic.title.toLowerCase().includes(trimmed) ||
         topic.englishTitle.toLowerCase().includes(trimmed)
     );
-  }, [activeCategory, query]);
+  }, [activeCategory, activeCategoryId, query, surveyCheckedIds]);
+
+  const groupedSurveyTopics = useMemo(() => {
+    if (activeCategoryId !== CATEGORY_SURVEY) return [];
+    const grouped = new Map<string, TopicItem[]>();
+    filteredTopics.forEach((topic) => {
+      const group = resolveSurveyGroup(topic);
+      if (!grouped.has(group)) grouped.set(group, []);
+      grouped.get(group)?.push(topic);
+    });
+    return Array.from(grouped.entries())
+      .map(([group, items]) => ({ group, items }))
+      .sort((a, b) => a.group.localeCompare(b.group, "ko"));
+  }, [activeCategoryId, filteredTopics]);
 
   const selectedTopic = useMemo<TopicItem | undefined>(
     () => topics.find((t) => t.id === selectedId),
@@ -99,6 +149,12 @@ export function TopicPracticeView({ userLabel, onLogout }: Props) {
   const handleSelect = (topic: TopicItem) => {
     setError(null);
     setSelectedId((prev) => (prev === topic.id ? null : topic.id));
+  };
+
+  const toggleSurveyCheck = (topicId: string) => {
+    setSurveyCheckedIds((prev) =>
+      prev.includes(topicId) ? prev.filter((id) => id !== topicId) : [...prev, topicId]
+    );
   };
 
   const handleSubmit = async () => {
@@ -226,7 +282,13 @@ export function TopicPracticeView({ userLabel, onLogout }: Props) {
                     <button
                       key={category.id}
                       type="button"
-                      onClick={() => setActiveCategoryId(category.id)}
+                      onClick={() => {
+                        setActiveCategoryId(category.id);
+                        setQuery("");
+                        if (category.id !== CATEGORY_SURVEY) {
+                          setSurveyCheckedIds([]);
+                        }
+                      }}
                       className={`rounded-2xl border px-4 py-3 text-left transition ${
                         isActive
                           ? "border-transparent bg-[var(--accent)] text-white shadow-sm"
@@ -236,7 +298,7 @@ export function TopicPracticeView({ userLabel, onLogout }: Props) {
                       <div className="flex items-center justify-between">
                         <span className="font-semibold">{category.label}</span>
                         <span className={`text-xs ${isActive ? "text-white/80" : "text-[var(--muted)]"}`}>
-                          {category.topics.length} topics
+                          {category.topics.length} items
                         </span>
                       </div>
                       <p className={`mt-1 text-xs ${isActive ? "text-white/80" : "text-[var(--muted)]"}`}>
@@ -252,6 +314,11 @@ export function TopicPracticeView({ userLabel, onLogout }: Props) {
               <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--muted)]">
                 선택된 주제
               </p>
+              {activeCategoryId === CATEGORY_SURVEY ? (
+                <p className="mt-2 text-xs text-[var(--muted)]">
+                  체크한 설문 항목: {surveyCheckedIds.length}개
+                </p>
+              ) : null}
               {selectedTopic ? (
                 <div className="mt-4 rounded-2xl border border-[var(--accent)]/30 bg-[var(--accent)]/10 p-4">
                   <p className="text-sm font-semibold">{selectedTopic.title}</p>
@@ -301,6 +368,70 @@ export function TopicPracticeView({ userLabel, onLogout }: Props) {
               <div className="mt-6 grid gap-4 sm:grid-cols-2">
                 {Array.from({ length: 6 }).map((_, i) => (
                   <div key={`skeleton-${i}`} className="h-24 rounded-3xl border border-black/10 bg-white/60 animate-pulse" />
+                ))}
+              </div>
+            ) : activeCategoryId === CATEGORY_SURVEY ? (
+              <div className="mt-6 space-y-5">
+                {groupedSurveyTopics.length === 0 ? (
+                  <p className="text-sm text-[var(--muted)]">조건에 맞는 설문 항목이 없습니다.</p>
+                ) : null}
+                {groupedSurveyTopics.map(({ group, items }) => (
+                  <div key={group} className="space-y-3">
+                    <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--muted)]">
+                      {group}
+                    </p>
+                    <div className="grid gap-4 sm:grid-cols-2">
+                      {items.map((topic) => {
+                        const isSelected = selectedId === topic.id;
+                        const isChecked = surveyCheckedIds.includes(topic.id);
+                        return (
+                          <button
+                            key={topic.id}
+                            type="button"
+                            onClick={() => handleSelect(topic)}
+                            className={`rounded-3xl border p-4 text-left transition ${
+                              isSelected
+                                ? "border-transparent bg-[var(--accent)] text-white shadow-lg shadow-[var(--accent)]/20"
+                                : "border-black/10 bg-white hover:border-[var(--accent)]/40"
+                            }`}
+                          >
+                            <div className="flex items-start justify-between gap-3">
+                              <div>
+                                <p className="text-base font-semibold">{topic.title}</p>
+                                <p className={`mt-1 text-xs ${isSelected ? "text-white/80" : "text-[var(--muted)]"}`}>
+                                  {topic.englishTitle}
+                                </p>
+                              </div>
+                              <span className={`rounded-full px-2.5 py-1 text-[10px] font-semibold ${
+                                isSelected ? "bg-white/20 text-white" : "bg-[var(--accent)]/10 text-[var(--accent-strong)]"
+                              }`}>
+                                {isSelected ? "선택됨" : "선택"}
+                              </span>
+                            </div>
+                            <label
+                              className={`mt-3 flex items-center gap-2 text-xs font-semibold ${
+                                isSelected ? "text-white" : "text-[var(--accent-strong)]"
+                              }`}
+                              onClick={(event) => {
+                                event.stopPropagation();
+                              }}
+                            >
+                              <input
+                                type="checkbox"
+                                checked={isChecked}
+                                onChange={(event) => {
+                                  event.stopPropagation();
+                                  toggleSurveyCheck(topic.id);
+                                }}
+                                className="h-4 w-4 accent-[var(--accent)]"
+                              />
+                              설문 항목 체크
+                            </label>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
                 ))}
               </div>
             ) : (


### PR DESCRIPTION
## Summary
- 주제별 연습 카테고리를 `자기소개 / 설문조사 / 돌발질문` 3분류로 고정
- 백엔드 부트스트랩 러너 추가
  - 기존 토픽 카테고리 재분류(legacy `돌발/상황 대처` -> `돌발질문`)
  - `자기소개` 토픽 자동 생성(없을 때)
  - `자기소개` 질문 4개 자동 시드(없을 때)
- 프론트 주제 선택 화면 개편
  - 3카테고리 기준 렌더링
  - 설문조사 카테고리에서 항목 체크(다중) + 체크 기반 필터
  - 최종 연습 시작은 기존과 동일하게 단일 주제 선택 유지

## Commits
1. `feat(topic): bootstrap three practice categories and self-intro topic`
2. `test(topic): verify category reclassify and self-intro seeding`
3. `feat(practice-web): add 3-category view and survey checkbox filtering`

## Test
- `./gradlew test --tests com.opicer.api.topic.infrastructure.PracticeTopicBootstrapRunnerTest --tests com.opicer.api.practice.presentation.TopicSelectionControllerTest --tests com.opicer.api.practice.presentation.PracticeQuestionControllerTest` ✅
- `pnpm -C opicer-web exec tsc --noEmit` 실행 시 기존 파일 `src/features/mypage/components/MyPageView.tsx`의 선행 타입 오류(`Property 'id' does not exist on type 'never'`)로 실패 (본 PR 변경과 무관)

Closes #67