### PR TITLE
feat: 주제별 연습 제출 시 2크레딧 차감 및 중복 차감 방지

### DIFF
--- a/opicer-api/src/main/java/com/opicer/api/credit/application/CreditBalanceService.java
+++ b/opicer-api/src/main/java/com/opicer/api/credit/application/CreditBalanceService.java
@@ -44,4 +44,17 @@ public class CreditBalanceService {
 		return creditBalanceRepository.findByUserId(userId)
 			.orElseThrow(() -> new IllegalArgumentException("Balance not found"));
 	}
+
+	@Transactional(readOnly = true)
+	public boolean hasEnough(UUID userId, long amount) {
+		return creditBalanceRepository.findByUserId(userId)
+			.map(balance -> balance.getBalance() >= amount)
+			.orElse(false);
+	}
+
+	@Transactional
+	public boolean deductIfEnough(UUID userId, long amount) {
+		log.info("Deducting credit balance. userId={}, amount={}", userId, amount);
+		return creditBalanceRepository.deductIfEnough(userId, amount) > 0;
+	}
 }

--- a/opicer-api/src/main/java/com/opicer/api/credit/infrastructure/CreditBalanceRepository.java
+++ b/opicer-api/src/main/java/com/opicer/api/credit/infrastructure/CreditBalanceRepository.java
@@ -14,4 +14,12 @@ public interface CreditBalanceRepository extends JpaRepository<CreditBalance, UU
 	@Modifying
 	@Query("update CreditBalance b set b.balance = b.balance + :delta where b.userId = :userId")
 	int addBalance(@Param("userId") UUID userId, @Param("delta") long delta);
+
+	@Modifying
+	@Query("""
+		update CreditBalance b
+		set b.balance = b.balance - :amount
+		where b.userId = :userId and b.balance >= :amount
+		""")
+	int deductIfEnough(@Param("userId") UUID userId, @Param("amount") long amount);
 }

--- a/opicer-api/src/main/java/com/opicer/api/practice/application/PracticeSessionService.java
+++ b/opicer-api/src/main/java/com/opicer/api/practice/application/PracticeSessionService.java
@@ -1,0 +1,60 @@
+package com.opicer.api.practice.application;
+
+import com.opicer.api.credit.application.CreditBalanceService;
+import com.opicer.api.practice.domain.PracticeCreditCharge;
+import com.opicer.api.practice.domain.TopicSelection;
+import com.opicer.api.practice.infrastructure.PracticeCreditChargeRepository;
+import com.opicer.api.practice.infrastructure.TopicSelectionRepository;
+import com.opicer.api.shared.error.ApiException;
+import com.opicer.api.shared.error.ErrorCode;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class PracticeSessionService {
+
+	private static final int PRACTICE_COST = 2;
+
+	private final TopicSelectionRepository topicSelectionRepository;
+	private final PracticeCreditChargeRepository practiceCreditChargeRepository;
+	private final CreditBalanceService creditBalanceService;
+
+	public PracticeSessionService(
+		TopicSelectionRepository topicSelectionRepository,
+		PracticeCreditChargeRepository practiceCreditChargeRepository,
+		CreditBalanceService creditBalanceService
+	) {
+		this.topicSelectionRepository = topicSelectionRepository;
+		this.practiceCreditChargeRepository = practiceCreditChargeRepository;
+		this.creditBalanceService = creditBalanceService;
+	}
+
+	@Transactional
+	public SubmitResult submit(UUID userId, UUID topicSelectionId) {
+		TopicSelection selection = topicSelectionRepository.findLockedByIdAndUserId(topicSelectionId, userId)
+			.orElseThrow(() -> new ApiException(ErrorCode.TOPIC_SELECTION_NOT_FOUND));
+
+		PracticeCreditCharge existing = practiceCreditChargeRepository.findByTopicSelectionId(selection.getId())
+			.orElse(null);
+		if (existing != null) {
+			return new SubmitResult(existing.getId(), true, existing.getAmount());
+		}
+
+		boolean deducted = creditBalanceService.deductIfEnough(userId, PRACTICE_COST);
+		if (!deducted) {
+			throw new ApiException(ErrorCode.CREDIT_INSUFFICIENT_BALANCE, "At least 2 credits are required to submit practice");
+		}
+
+		PracticeCreditCharge charge = practiceCreditChargeRepository.save(
+			new PracticeCreditCharge(userId, selection.getId(), PRACTICE_COST)
+		);
+		return new SubmitResult(charge.getId(), false, PRACTICE_COST);
+	}
+
+	public record SubmitResult(
+		UUID chargeId,
+		boolean alreadyCharged,
+		int deductedCredits
+	) {}
+}

--- a/opicer-api/src/main/java/com/opicer/api/practice/application/TopicSelectionService.java
+++ b/opicer-api/src/main/java/com/opicer/api/practice/application/TopicSelectionService.java
@@ -1,7 +1,10 @@
 package com.opicer.api.practice.application;
 
+import com.opicer.api.credit.application.CreditBalanceService;
 import com.opicer.api.practice.domain.TopicSelection;
 import com.opicer.api.practice.infrastructure.TopicSelectionRepository;
+import com.opicer.api.shared.error.ApiException;
+import com.opicer.api.shared.error.ErrorCode;
 import com.opicer.api.topic.application.TopicService;
 import com.opicer.api.topic.domain.Topic;
 import java.util.UUID;
@@ -13,14 +16,23 @@ public class TopicSelectionService {
 
 	private final TopicSelectionRepository topicSelectionRepository;
 	private final TopicService topicService;
+	private final CreditBalanceService creditBalanceService;
 
-	public TopicSelectionService(TopicSelectionRepository topicSelectionRepository, TopicService topicService) {
+	public TopicSelectionService(
+		TopicSelectionRepository topicSelectionRepository,
+		TopicService topicService,
+		CreditBalanceService creditBalanceService
+	) {
 		this.topicSelectionRepository = topicSelectionRepository;
 		this.topicService = topicService;
+		this.creditBalanceService = creditBalanceService;
 	}
 
 	@Transactional
 	public TopicSelection createSelection(UUID userId, UUID topicId) {
+		if (!creditBalanceService.hasEnough(userId, 2)) {
+			throw new ApiException(ErrorCode.CREDIT_INSUFFICIENT_BALANCE, "At least 2 credits are required to start practice");
+		}
 		Topic topic = topicService.getActiveOrThrow(topicId);
 		TopicSelection selection = new TopicSelection(userId, topic.getId());
 		return topicSelectionRepository.save(selection);

--- a/opicer-api/src/main/java/com/opicer/api/practice/domain/PracticeCreditCharge.java
+++ b/opicer-api/src/main/java/com/opicer/api/practice/domain/PracticeCreditCharge.java
@@ -1,0 +1,55 @@
+package com.opicer.api.practice.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(
+	name = "practice_credit_charge",
+	uniqueConstraints = @UniqueConstraint(name = "uk_practice_credit_charge_topic_selection", columnNames = {"topic_selection_id"})
+)
+public class PracticeCreditCharge {
+
+	@Id
+	@GeneratedValue
+	private UUID id;
+
+	@Column(name = "user_id", nullable = false)
+	private UUID userId;
+
+	@Column(name = "topic_selection_id", nullable = false)
+	private UUID topicSelectionId;
+
+	@Column(nullable = false)
+	private int amount;
+
+	@Column(name = "charged_at", nullable = false)
+	private Instant chargedAt;
+
+	protected PracticeCreditCharge() {
+	}
+
+	public PracticeCreditCharge(UUID userId, UUID topicSelectionId, int amount) {
+		this.userId = userId;
+		this.topicSelectionId = topicSelectionId;
+		this.amount = amount;
+	}
+
+	@PrePersist
+	void onCreate() {
+		this.chargedAt = Instant.now();
+	}
+
+	public UUID getId() { return id; }
+	public UUID getUserId() { return userId; }
+	public UUID getTopicSelectionId() { return topicSelectionId; }
+	public int getAmount() { return amount; }
+	public Instant getChargedAt() { return chargedAt; }
+}

--- a/opicer-api/src/main/java/com/opicer/api/practice/infrastructure/PracticeCreditChargeRepository.java
+++ b/opicer-api/src/main/java/com/opicer/api/practice/infrastructure/PracticeCreditChargeRepository.java
@@ -1,0 +1,11 @@
+package com.opicer.api.practice.infrastructure;
+
+import com.opicer.api.practice.domain.PracticeCreditCharge;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PracticeCreditChargeRepository extends JpaRepository<PracticeCreditCharge, UUID> {
+	Optional<PracticeCreditCharge> findByTopicSelectionId(UUID topicSelectionId);
+	long countByTopicSelectionId(UUID topicSelectionId);
+}

--- a/opicer-api/src/main/java/com/opicer/api/practice/infrastructure/PracticeCreditChargeSchemaHardening.java
+++ b/opicer-api/src/main/java/com/opicer/api/practice/infrastructure/PracticeCreditChargeSchemaHardening.java
@@ -55,5 +55,53 @@ public class PracticeCreditChargeSchemaHardening implements ApplicationRunner {
 			END
 			$$;
 			""");
+		jdbcTemplate.execute("""
+			DO $$
+			BEGIN
+			  IF NOT EXISTS (
+			    SELECT 1
+			    FROM pg_constraint
+			    WHERE conname = 'fk_practice_credit_charge_topic_selection'
+			  ) THEN
+			    IF NOT EXISTS (
+			      SELECT 1
+			      FROM practice_credit_charge p
+			      LEFT JOIN topic_selection t ON t.id = p.topic_selection_id
+			      WHERE t.id IS NULL
+			    ) THEN
+			      ALTER TABLE practice_credit_charge
+			        ADD CONSTRAINT fk_practice_credit_charge_topic_selection
+			        FOREIGN KEY (topic_selection_id) REFERENCES topic_selection(id);
+			    ELSE
+			      RAISE NOTICE 'Skip adding fk_practice_credit_charge_topic_selection due to orphan rows';
+			    END IF;
+			  END IF;
+			END
+			$$;
+			""");
+		jdbcTemplate.execute("""
+			DO $$
+			BEGIN
+			  IF NOT EXISTS (
+			    SELECT 1
+			    FROM pg_constraint
+			    WHERE conname = 'fk_practice_credit_charge_user'
+			  ) THEN
+			    IF NOT EXISTS (
+			      SELECT 1
+			      FROM practice_credit_charge p
+			      LEFT JOIN app_user u ON u.id = p.user_id
+			      WHERE u.id IS NULL
+			    ) THEN
+			      ALTER TABLE practice_credit_charge
+			        ADD CONSTRAINT fk_practice_credit_charge_user
+			        FOREIGN KEY (user_id) REFERENCES app_user(id);
+			    ELSE
+			      RAISE NOTICE 'Skip adding fk_practice_credit_charge_user due to orphan rows';
+			    END IF;
+			  END IF;
+			END
+			$$;
+			""");
 	}
 }

--- a/opicer-api/src/main/java/com/opicer/api/practice/infrastructure/PracticeCreditChargeSchemaHardening.java
+++ b/opicer-api/src/main/java/com/opicer/api/practice/infrastructure/PracticeCreditChargeSchemaHardening.java
@@ -1,0 +1,59 @@
+package com.opicer.api.practice.infrastructure;
+
+import java.sql.Connection;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PracticeCreditChargeSchemaHardening implements ApplicationRunner {
+
+	private static final Logger log = LoggerFactory.getLogger(PracticeCreditChargeSchemaHardening.class);
+
+	private final DataSource dataSource;
+	private final JdbcTemplate jdbcTemplate;
+
+	public PracticeCreditChargeSchemaHardening(DataSource dataSource, JdbcTemplate jdbcTemplate) {
+		this.dataSource = dataSource;
+		this.jdbcTemplate = jdbcTemplate;
+	}
+
+	@Override
+	public void run(ApplicationArguments args) throws Exception {
+		try (Connection connection = dataSource.getConnection()) {
+			String databaseProductName = connection.getMetaData().getDatabaseProductName();
+			if (!"PostgreSQL".equalsIgnoreCase(databaseProductName)) {
+				return;
+			}
+		}
+
+		log.info("Ensuring practice_credit_charge table and unique constraint");
+		jdbcTemplate.execute("""
+			CREATE TABLE IF NOT EXISTS practice_credit_charge (
+			  id UUID PRIMARY KEY,
+			  user_id UUID NOT NULL,
+			  topic_selection_id UUID NOT NULL,
+			  amount INTEGER NOT NULL,
+			  charged_at TIMESTAMP(6) WITH TIME ZONE NOT NULL
+			);
+			""");
+		jdbcTemplate.execute("""
+			DO $$
+			BEGIN
+			  IF NOT EXISTS (
+			    SELECT 1
+			    FROM pg_constraint
+			    WHERE conname = 'uk_practice_credit_charge_topic_selection'
+			  ) THEN
+			    ALTER TABLE practice_credit_charge
+			      ADD CONSTRAINT uk_practice_credit_charge_topic_selection UNIQUE (topic_selection_id);
+			  END IF;
+			END
+			$$;
+			""");
+	}
+}

--- a/opicer-api/src/main/java/com/opicer/api/practice/infrastructure/TopicSelectionRepository.java
+++ b/opicer-api/src/main/java/com/opicer/api/practice/infrastructure/TopicSelectionRepository.java
@@ -1,8 +1,18 @@
 package com.opicer.api.practice.infrastructure;
 
 import com.opicer.api.practice.domain.TopicSelection;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TopicSelectionRepository extends JpaRepository<TopicSelection, UUID> {
+	Optional<TopicSelection> findByIdAndUserId(UUID id, UUID userId);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("select t from TopicSelection t where t.id = :id and t.userId = :userId")
+	Optional<TopicSelection> findLockedByIdAndUserId(@Param("id") UUID id, @Param("userId") UUID userId);
 }

--- a/opicer-api/src/main/java/com/opicer/api/practice/presentation/PracticeSessionController.java
+++ b/opicer-api/src/main/java/com/opicer/api/practice/presentation/PracticeSessionController.java
@@ -1,0 +1,51 @@
+package com.opicer.api.practice.presentation;
+
+import com.opicer.api.auth.domain.AuthUserPrincipal;
+import com.opicer.api.practice.application.PracticeSessionService;
+import com.opicer.api.shared.presentation.ApiResponse;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/practice/sessions")
+public class PracticeSessionController {
+
+	private final PracticeSessionService practiceSessionService;
+
+	public PracticeSessionController(PracticeSessionService practiceSessionService) {
+		this.practiceSessionService = practiceSessionService;
+	}
+
+	@PostMapping("/submit")
+	public ResponseEntity<ApiResponse<SubmitResponse>> submit(
+		Authentication authentication,
+		@Valid @RequestBody SubmitRequest request
+	) {
+		if (authentication == null || !(authentication.getPrincipal() instanceof AuthUserPrincipal principal)) {
+			return ResponseEntity.status(401).build();
+		}
+		PracticeSessionService.SubmitResult result = practiceSessionService.submit(principal.id(), request.topicSelectionId());
+		return ResponseEntity.ok(ApiResponse.ok("PRACTICE_SUBMITTED", new SubmitResponse(
+			result.chargeId(),
+			result.alreadyCharged(),
+			result.deductedCredits()
+		)));
+	}
+
+	public record SubmitRequest(@NotNull UUID topicSelectionId) {
+	}
+
+	public record SubmitResponse(
+		UUID chargeId,
+		boolean alreadyCharged,
+		int deductedCredits
+	) {
+	}
+}

--- a/opicer-api/src/main/java/com/opicer/api/shared/error/ErrorCode.java
+++ b/opicer-api/src/main/java/com/opicer/api/shared/error/ErrorCode.java
@@ -21,7 +21,9 @@ public enum ErrorCode {
 	AI_ANALYSIS_FAILED("AI_ANALYSIS_FAILED", HttpStatus.BAD_GATEWAY, "AI analysis failed"),
 	AI_EMBEDDING_FAILED("AI_EMBEDDING_FAILED", HttpStatus.BAD_GATEWAY, "Embedding generation failed"),
 	AI_RAG_FAILED("AI_RAG_FAILED", HttpStatus.BAD_GATEWAY, "RAG retrieval failed"),
-	IDEMPOTENCY_KEY_CONFLICT("IDEMPOTENCY_KEY_CONFLICT", HttpStatus.CONFLICT, "Idempotency key already used with different request");
+	IDEMPOTENCY_KEY_CONFLICT("IDEMPOTENCY_KEY_CONFLICT", HttpStatus.CONFLICT, "Idempotency key already used with different request"),
+	TOPIC_SELECTION_NOT_FOUND("TOPIC_SELECTION_NOT_FOUND", HttpStatus.NOT_FOUND, "Topic selection not found"),
+	CREDIT_INSUFFICIENT_BALANCE("CREDIT_INSUFFICIENT_BALANCE", HttpStatus.PAYMENT_REQUIRED, "Insufficient credits");
 
 	private final String code;
 	private final HttpStatus httpStatus;

--- a/opicer-api/src/test/java/com/opicer/api/practice/application/PracticeSessionServiceTest.java
+++ b/opicer-api/src/test/java/com/opicer/api/practice/application/PracticeSessionServiceTest.java
@@ -1,0 +1,105 @@
+package com.opicer.api.practice.application;
+
+import com.opicer.api.credit.application.CreditBalanceService;
+import com.opicer.api.practice.domain.TopicSelection;
+import com.opicer.api.practice.infrastructure.PracticeCreditChargeRepository;
+import com.opicer.api.practice.infrastructure.TopicSelectionRepository;
+import com.opicer.api.shared.error.ApiException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+class PracticeSessionServiceTest {
+
+	@Autowired
+	private PracticeSessionService practiceSessionService;
+
+	@Autowired
+	private TopicSelectionRepository topicSelectionRepository;
+
+	@Autowired
+	private PracticeCreditChargeRepository practiceCreditChargeRepository;
+
+	@Autowired
+	private CreditBalanceService creditBalanceService;
+
+	@BeforeEach
+	void setUp() {
+		practiceCreditChargeRepository.deleteAll();
+		topicSelectionRepository.deleteAll();
+	}
+
+	@Test
+	void submitDeductsOnlyOnceForSameSelection() {
+		UUID userId = UUID.randomUUID();
+		creditBalanceService.ensureBalance(userId);
+		creditBalanceService.addBalance(userId, 10);
+		TopicSelection selection = topicSelectionRepository.save(new TopicSelection(userId, UUID.randomUUID()));
+
+		PracticeSessionService.SubmitResult first = practiceSessionService.submit(userId, selection.getId());
+		PracticeSessionService.SubmitResult second = practiceSessionService.submit(userId, selection.getId());
+
+		assertThat(first.alreadyCharged()).isFalse();
+		assertThat(second.alreadyCharged()).isTrue();
+		assertThat(practiceCreditChargeRepository.countByTopicSelectionId(selection.getId())).isEqualTo(1);
+		assertThat(creditBalanceService.getBalance(userId).getBalance()).isEqualTo(8);
+	}
+
+	@Test
+	void submitConcurrentRequestsDeductsOnce() throws Exception {
+		UUID userId = UUID.randomUUID();
+		creditBalanceService.ensureBalance(userId);
+		creditBalanceService.addBalance(userId, 10);
+		TopicSelection selection = topicSelectionRepository.save(new TopicSelection(userId, UUID.randomUUID()));
+
+		ExecutorService pool = Executors.newFixedThreadPool(10);
+		CountDownLatch ready = new CountDownLatch(10);
+		CountDownLatch start = new CountDownLatch(1);
+		List<Future<Boolean>> futures = new ArrayList<>();
+
+		for (int i = 0; i < 10; i++) {
+			futures.add(pool.submit(() -> {
+				ready.countDown();
+				start.await();
+				practiceSessionService.submit(userId, selection.getId());
+				return true;
+			}));
+		}
+
+		ready.await();
+		start.countDown();
+		for (Future<Boolean> future : futures) {
+			assertThat(future.get()).isTrue();
+		}
+		pool.shutdown();
+
+		assertThat(practiceCreditChargeRepository.countByTopicSelectionId(selection.getId())).isEqualTo(1);
+		assertThat(creditBalanceService.getBalance(userId).getBalance()).isEqualTo(8);
+	}
+
+	@Test
+	void submitFailsWhenBalanceIsInsufficient() {
+		UUID userId = UUID.randomUUID();
+		creditBalanceService.ensureBalance(userId);
+		creditBalanceService.addBalance(userId, 1);
+		TopicSelection selection = topicSelectionRepository.save(new TopicSelection(userId, UUID.randomUUID()));
+
+		assertThatThrownBy(() -> practiceSessionService.submit(userId, selection.getId()))
+			.isInstanceOf(ApiException.class)
+			.hasMessageContaining("At least 2 credits");
+		assertThat(practiceCreditChargeRepository.countByTopicSelectionId(selection.getId())).isZero();
+		assertThat(creditBalanceService.getBalance(userId).getBalance()).isEqualTo(1);
+	}
+}

--- a/opicer-api/src/test/java/com/opicer/api/practice/application/PracticeSessionServiceTest.java
+++ b/opicer-api/src/test/java/com/opicer/api/practice/application/PracticeSessionServiceTest.java
@@ -8,10 +8,12 @@ import com.opicer.api.shared.error.ApiException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -90,6 +92,91 @@ class PracticeSessionServiceTest {
 	}
 
 	@Test
+	void submitHighLoadConcurrentRequestsDeductsOnce() throws Exception {
+		UUID userId = UUID.randomUUID();
+		creditBalanceService.ensureBalance(userId);
+		creditBalanceService.addBalance(userId, 100);
+		TopicSelection selection = topicSelectionRepository.save(new TopicSelection(userId, UUID.randomUUID()));
+
+		int threadPool = 10;
+		int totalRequests = 500;
+		ExecutorService pool = Executors.newFixedThreadPool(threadPool);
+		CountDownLatch ready = new CountDownLatch(totalRequests);
+		CountDownLatch start = new CountDownLatch(1);
+		AtomicInteger successCount = new AtomicInteger();
+
+		List<Future<Boolean>> futures = new ArrayList<>();
+		for (int i = 0; i < totalRequests; i++) {
+			futures.add(pool.submit(() -> {
+				ready.countDown();
+				start.await();
+				practiceSessionService.submit(userId, selection.getId());
+				successCount.incrementAndGet();
+				return true;
+			}));
+		}
+
+		ready.await();
+		start.countDown();
+		for (Future<Boolean> future : futures) {
+			assertThat(future.get()).isTrue();
+		}
+		pool.shutdown();
+
+		assertThat(successCount.get()).isEqualTo(totalRequests);
+		assertThat(practiceCreditChargeRepository.countByTopicSelectionId(selection.getId())).isEqualTo(1);
+		assertThat(creditBalanceService.getBalance(userId).getBalance()).isEqualTo(98);
+	}
+
+	@Test
+	void submitConcurrentDifferentSelectionsWithExactBalance_doesNotGoNegative() throws Exception {
+		UUID userId = UUID.randomUUID();
+		creditBalanceService.ensureBalance(userId);
+		creditBalanceService.addBalance(userId, 2);
+
+		TopicSelection first = topicSelectionRepository.save(new TopicSelection(userId, UUID.randomUUID()));
+		TopicSelection second = topicSelectionRepository.save(new TopicSelection(userId, UUID.randomUUID()));
+
+		ExecutorService pool = Executors.newFixedThreadPool(2);
+		CountDownLatch ready = new CountDownLatch(2);
+		CountDownLatch start = new CountDownLatch(1);
+		List<Future<Boolean>> futures = List.of(
+			pool.submit(callSubmit(userId, first.getId(), ready, start)),
+			pool.submit(callSubmit(userId, second.getId(), ready, start))
+		);
+		ready.await();
+		start.countDown();
+
+		int success = 0;
+		int failed = 0;
+		for (Future<Boolean> future : futures) {
+			if (future.get()) success++;
+			else failed++;
+		}
+		pool.shutdown();
+
+		assertThat(success).isEqualTo(1);
+		assertThat(failed).isEqualTo(1);
+		assertThat(creditBalanceService.getBalance(userId).getBalance()).isZero();
+		assertThat(practiceCreditChargeRepository.count()).isEqualTo(1);
+	}
+
+	@Test
+	void submitWithUnknownSelectionOwnedByOtherUser_returnsNotFound() {
+		UUID owner = UUID.randomUUID();
+		UUID attacker = UUID.randomUUID();
+		creditBalanceService.ensureBalance(owner);
+		creditBalanceService.addBalance(owner, 10);
+		creditBalanceService.ensureBalance(attacker);
+		creditBalanceService.addBalance(attacker, 10);
+		TopicSelection selection = topicSelectionRepository.save(new TopicSelection(owner, UUID.randomUUID()));
+
+		assertThatThrownBy(() -> practiceSessionService.submit(attacker, selection.getId()))
+			.isInstanceOf(ApiException.class)
+			.hasMessageContaining("Topic selection not found");
+	}
+
+	@Test
 	void submitFailsWhenBalanceIsInsufficient() {
 		UUID userId = UUID.randomUUID();
 		creditBalanceService.ensureBalance(userId);
@@ -101,5 +188,23 @@ class PracticeSessionServiceTest {
 			.hasMessageContaining("At least 2 credits");
 		assertThat(practiceCreditChargeRepository.countByTopicSelectionId(selection.getId())).isZero();
 		assertThat(creditBalanceService.getBalance(userId).getBalance()).isEqualTo(1);
+	}
+
+	private Callable<Boolean> callSubmit(
+		UUID userId,
+		UUID selectionId,
+		CountDownLatch ready,
+		CountDownLatch start
+	) {
+		return () -> {
+			ready.countDown();
+			start.await();
+			try {
+				practiceSessionService.submit(userId, selectionId);
+				return true;
+			} catch (ApiException ex) {
+				return false;
+			}
+		};
 	}
 }

--- a/opicer-api/src/test/java/com/opicer/api/practice/presentation/PracticeSessionControllerTest.java
+++ b/opicer-api/src/test/java/com/opicer/api/practice/presentation/PracticeSessionControllerTest.java
@@ -1,0 +1,96 @@
+package com.opicer.api.practice.presentation;
+
+import com.opicer.api.auth.application.JwtService;
+import com.opicer.api.auth.domain.AuthUserPrincipal;
+import com.opicer.api.config.AuthProperties;
+import com.opicer.api.practice.application.PracticeSessionService;
+import com.opicer.api.shared.error.ApiException;
+import com.opicer.api.shared.error.ErrorCode;
+import com.opicer.api.user.domain.AuthProvider;
+import com.opicer.api.user.domain.UserRole;
+import jakarta.servlet.http.Cookie;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class PracticeSessionControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JwtService jwtService;
+
+	@Autowired
+	private AuthProperties authProperties;
+
+	@MockBean
+	private PracticeSessionService practiceSessionService;
+
+	private Cookie userCookie;
+
+	@BeforeEach
+	void setUp() {
+		userCookie = new Cookie(authProperties.getCookieName(), jwtService.issueToken(
+			new AuthUserPrincipal(
+				UUID.randomUUID(),
+				"user@example.com",
+				"User",
+				UserRole.USER,
+				AuthProvider.KAKAO
+			)
+		));
+	}
+
+	@Test
+	void submitSuccessReturns200() throws Exception {
+		PracticeSessionService.SubmitResult result = new PracticeSessionService.SubmitResult(
+			UUID.randomUUID(),
+			false,
+			2
+		);
+		when(practiceSessionService.submit(any(), any())).thenReturn(result);
+
+		mockMvc.perform(post("/api/practice/sessions/submit")
+				.cookie(userCookie)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "topicSelectionId": "11111111-1111-1111-1111-111111111111"
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.deductedCredits").value(2));
+	}
+
+	@Test
+	void submitInsufficientBalanceReturns402() throws Exception {
+		when(practiceSessionService.submit(any(), any()))
+			.thenThrow(new ApiException(ErrorCode.CREDIT_INSUFFICIENT_BALANCE));
+
+		mockMvc.perform(post("/api/practice/sessions/submit")
+				.cookie(userCookie)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "topicSelectionId": "11111111-1111-1111-1111-111111111111"
+					}
+					"""))
+			.andExpect(status().isPaymentRequired())
+			.andExpect(jsonPath("$.code").value("CREDIT_INSUFFICIENT_BALANCE"));
+	}
+}

--- a/opicer-api/src/test/java/com/opicer/api/practice/presentation/TopicSelectionControllerTest.java
+++ b/opicer-api/src/test/java/com/opicer/api/practice/presentation/TopicSelectionControllerTest.java
@@ -3,6 +3,8 @@ package com.opicer.api.practice.presentation;
 import com.opicer.api.auth.application.JwtService;
 import com.opicer.api.auth.domain.AuthUserPrincipal;
 import com.opicer.api.config.AuthProperties;
+import com.opicer.api.credit.domain.CreditBalance;
+import com.opicer.api.credit.infrastructure.CreditBalanceRepository;
 import com.opicer.api.topic.domain.Topic;
 import com.opicer.api.topic.infrastructure.TopicRepository;
 import com.opicer.api.user.domain.AuthProvider;
@@ -37,20 +39,29 @@ class TopicSelectionControllerTest {
 	@Autowired
 	private TopicRepository topicRepository;
 
+	@Autowired
+	private CreditBalanceRepository creditBalanceRepository;
+
 	private jakarta.servlet.http.Cookie userCookie;
+	private UUID userId;
 
 	@BeforeEach
 	void setUp() {
 		topicRepository.deleteAll();
+		creditBalanceRepository.deleteAll();
+		userId = UUID.randomUUID();
 		userCookie = new jakarta.servlet.http.Cookie(authProperties.getCookieName(), jwtService.issueToken(
 			new AuthUserPrincipal(
-				UUID.randomUUID(),
+				userId,
 				"user@example.com",
 				"User",
 				UserRole.USER,
 				AuthProvider.KAKAO
 			)
 		));
+		CreditBalance balance = new CreditBalance(userId);
+		balance.increase(10);
+		creditBalanceRepository.save(balance);
 	}
 
 	@Test
@@ -85,5 +96,26 @@ class TopicSelectionControllerTest {
 					""".formatted(topic.getId())))
 			.andExpect(status().isConflict())
 			.andExpect(jsonPath("$.code").value("TOPIC_INACTIVE"));
+	}
+
+	@Test
+	void createSelectionWithoutEnoughCreditReturns402() throws Exception {
+		creditBalanceRepository.deleteAll();
+		CreditBalance lowBalance = new CreditBalance(userId);
+		lowBalance.increase(1);
+		creditBalanceRepository.save(lowBalance);
+		Topic topic = new Topic("음악 감상", "Music", "설문조사", 1, 1, List.of(), true);
+		topic = topicRepository.save(topic);
+
+		mockMvc.perform(post("/api/practice/topic-selections")
+				.cookie(userCookie)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "topicId": "%s"
+					}
+					""".formatted(topic.getId())))
+			.andExpect(status().isPaymentRequired())
+			.andExpect(jsonPath("$.code").value("CREDIT_INSUFFICIENT_BALANCE"));
 	}
 }

--- a/opicer-web/src/app/api/practice/sessions/submit/route.ts
+++ b/opicer-web/src/app/api/practice/sessions/submit/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const baseUrl = process.env.OPICER_API_BASE_URL || "http://localhost:8080";
+
+export async function POST(request: NextRequest) {
+  const payload = await request.text();
+  const res = await fetch(`${baseUrl}/api/practice/sessions/submit`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      cookie: request.headers.get("cookie") ?? "",
+    },
+    body: payload,
+  });
+
+  const bodyText = await res.text();
+  if (!bodyText) return NextResponse.json(null, { status: res.status });
+
+  const body = JSON.parse(bodyText) as Record<string, unknown>;
+  if (!res.ok) {
+    return NextResponse.json(body, { status: res.status });
+  }
+
+  const data = (body as { data: Record<string, unknown> }).data;
+  return NextResponse.json(data, { status: res.status });
+}

--- a/opicer-web/src/app/practice/[topicId]/page.tsx
+++ b/opicer-web/src/app/practice/[topicId]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { useRouter, useParams } from "next/navigation";
+import { useRouter, useParams, useSearchParams } from "next/navigation";
 import { ROUTES } from "@/lib/routes";
 import { logout } from "@/lib/auth-client";
 import { useAuthState } from "@/lib/use-auth-state";
@@ -12,7 +12,9 @@ export default function PracticeSessionPage() {
   const auth = useAuthState();
   const router = useRouter();
   const params = useParams();
+  const searchParams = useSearchParams();
   const topicId = typeof params.topicId === "string" ? params.topicId : "";
+  const topicSelectionId = searchParams.get("selectionId") ?? "";
 
   useEffect(() => {
     if (auth.status === "unauthenticated") {
@@ -21,16 +23,16 @@ export default function PracticeSessionPage() {
   }, [auth.status, router]);
 
   useEffect(() => {
-    if (!topicId) {
+    if (!topicId || !topicSelectionId) {
       router.replace(ROUTES.practice);
     }
-  }, [topicId, router]);
+  }, [topicId, topicSelectionId, router]);
 
   if (auth.status === "loading" || auth.status === "unauthenticated") {
     return <LoadingScreen />;
   }
 
-  if (!topicId) return <LoadingScreen />;
+  if (!topicId || !topicSelectionId) return <LoadingScreen />;
 
   const handleLogout = async () => {
     await logout();
@@ -40,6 +42,7 @@ export default function PracticeSessionPage() {
   return (
     <PracticeSessionView
       topicId={topicId}
+      topicSelectionId={topicSelectionId}
       userLabel={auth.user.name ?? auth.user.email ?? "사용자"}
       onLogout={handleLogout}
     />

--- a/opicer-web/src/features/practice/api.ts
+++ b/opicer-web/src/features/practice/api.ts
@@ -1,5 +1,6 @@
 import type {
   PracticeQuestion,
+  PracticeSubmitResult,
   TopicItem,
   TopicSelection,
 } from "@/features/practice/types";
@@ -104,4 +105,19 @@ export async function improveScript(
   }
   const body = (await res.json()) as { improved: string };
   return body.improved;
+}
+
+export async function submitPracticeSession(
+  topicSelectionId: string
+): Promise<PracticeSubmitResult> {
+  const res = await fetch("/api/practice/sessions/submit", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ topicSelectionId }),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    throw new Error(body?.message ?? "Practice submit failed");
+  }
+  return (await res.json()) as PracticeSubmitResult;
 }

--- a/opicer-web/src/features/practice/components/PracticeSessionView.tsx
+++ b/opicer-web/src/features/practice/components/PracticeSessionView.tsx
@@ -7,6 +7,8 @@ import {
   analyzeAnswer,
   fetchPracticeQuestions,
   improveScript,
+  submitPracticeSession,
+  submitTopicSelection,
   transcribeAudio,
 } from "@/features/practice/api";
 import { ROUTES } from "@/lib/routes";
@@ -29,11 +31,12 @@ type QuestionAiState = {
 
 type Props = {
   topicId: string;
+  topicSelectionId: string;
   userLabel?: string;
   onLogout?: () => void;
 };
 
-export function PracticeSessionView({ topicId, userLabel, onLogout }: Props) {
+export function PracticeSessionView({ topicId, topicSelectionId, userLabel, onLogout }: Props) {
   const router = useRouter();
 
   // ── Core state ─────────────────────────────────────────────
@@ -160,7 +163,13 @@ export function PracticeSessionView({ topicId, userLabel, onLogout }: Props) {
           return { ...a, transcribeError };
         }
       })
-    ).then((updated) => {
+    ).then(async (updated) => {
+      try {
+        await submitPracticeSession(topicSelectionId);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "연습 제출 처리에 실패했습니다.";
+        setError(message);
+      }
       answersRef.current = updated;
       setAnswers(updated);
       setMode("summary");
@@ -538,19 +547,21 @@ export function PracticeSessionView({ topicId, userLabel, onLogout }: Props) {
             >
               다른 주제 연습하기
             </button>
-            <button
-              type="button"
-              onClick={() => {
-                answersRef.current = [];
-                setAnswers([]);
-                setAiStates({});
-                setCurrentIndex(0);
-                setMode("playing");
-              }}
-              className="text-sm text-[var(--muted)] hover:underline"
-            >
-              같은 주제 다시 연습하기
-            </button>
+              <button
+                type="button"
+                onClick={async () => {
+                  try {
+                    const selection = await submitTopicSelection(topicId);
+                    router.push(`${ROUTES.practiceSession(topicId)}?selectionId=${selection.id}`);
+                  } catch (err) {
+                    const message = err instanceof Error ? err.message : "새 연습 세션 생성에 실패했습니다.";
+                    setError(message);
+                  }
+                }}
+                className="text-sm text-[var(--muted)] hover:underline"
+              >
+                같은 주제 다시 연습하기
+              </button>
           </div>
         </div>
       </div>

--- a/opicer-web/src/features/practice/components/PracticeSessionView.tsx
+++ b/opicer-web/src/features/practice/components/PracticeSessionView.tsx
@@ -445,6 +445,13 @@ export function PracticeSessionView({ topicId, topicSelectionId, userLabel, onLo
         <div className="mx-auto flex max-w-4xl flex-col gap-8">
           <TopNav userLabel={userLabel} onLogout={onLogout} />
 
+          {error ? (
+            <section className="rounded-2xl border border-rose-300 bg-rose-50 p-4 text-sm text-rose-800">
+              <p className="font-semibold">크레딧 차감/제출 처리에 실패했습니다.</p>
+              <p className="mt-1">{error}</p>
+            </section>
+          ) : null}
+
           <section className="rounded-[32px] border border-black/5 bg-white/70 p-8 shadow-sm">
             <p className="text-xs uppercase tracking-[0.32em] text-[var(--muted)]">Practice Summary</p>
             <h1 className="mt-2 text-3xl font-semibold tracking-tight">연습 완료</h1>

--- a/opicer-web/src/features/practice/components/TopicPracticeView.tsx
+++ b/opicer-web/src/features/practice/components/TopicPracticeView.tsx
@@ -59,6 +59,7 @@ export function TopicPracticeView({ userLabel, onLogout }: Props) {
   const [activeCategoryId, setActiveCategoryId] = useState<string | null>(null);
   const [query, setQuery] = useState("");
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [selectedSelectionId, setSelectedSelectionId] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -143,6 +144,7 @@ export function TopicPracticeView({ userLabel, onLogout }: Props) {
 
   const handleSelect = (topic: TopicItem) => {
     setError(null);
+    setSelectedSelectionId(null);
     setSelectedId((prev) => (prev === topic.id ? null : topic.id));
   };
 
@@ -151,7 +153,8 @@ export function TopicPracticeView({ userLabel, onLogout }: Props) {
     setIsSubmitting(true);
     setError(null);
     try {
-      await submitTopicSelection(selectedId);
+      const selection = await submitTopicSelection(selectedId);
+      setSelectedSelectionId(selection.id);
       setMode("ready");
     } catch (err: any) {
       setError(err?.message ?? "선택 저장 중 문제가 발생했습니다.");
@@ -161,8 +164,8 @@ export function TopicPracticeView({ userLabel, onLogout }: Props) {
   };
 
   const handleStartPractice = () => {
-    if (!selectedId) return;
-    router.push(ROUTES.practiceSession(selectedId));
+    if (!selectedId || !selectedSelectionId) return;
+    router.push(`${ROUTES.practiceSession(selectedId)}?selectionId=${selectedSelectionId}`);
   };
 
   // ── Ready screen ───────────────────────────────────────────
@@ -205,7 +208,8 @@ export function TopicPracticeView({ userLabel, onLogout }: Props) {
               <button
                 type="button"
                 onClick={handleStartPractice}
-                className="rounded-full bg-[var(--accent)] px-10 py-4 text-base font-semibold text-white shadow-lg shadow-[var(--accent)]/20 transition hover:bg-[var(--accent-strong)]"
+                disabled={!selectedSelectionId}
+                className="rounded-full bg-[var(--accent)] px-10 py-4 text-base font-semibold text-white shadow-lg shadow-[var(--accent)]/20 transition hover:bg-[var(--accent-strong)] disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {selectedTopic?.title ?? ""}에 맞는 연습 시작하기
               </button>

--- a/opicer-web/src/features/practice/types.ts
+++ b/opicer-web/src/features/practice/types.ts
@@ -27,6 +27,12 @@ export type TopicSelection = {
   selectedAt: string;
 };
 
+export type PracticeSubmitResult = {
+  chargeId: string;
+  alreadyCharged: boolean;
+  deductedCredits: number;
+};
+
 export type PracticeQuestion = {
   id: string;
   topic: string;


### PR DESCRIPTION
## Summary
- 주제별 연습 제출 시점에 2크레딧 차감 로직 추가
- `topicSelectionId` 기준 차감 멱등 처리(동시/중복 제출 1회 차감)
- 시작(선택) 시점 잔액 2 이상 사전 검사 추가
- 잔액 부족 시 `402 PAYMENT_REQUIRED` + `CREDIT_INSUFFICIENT_BALANCE`
- 프론트는 `selectionId` 기반 세션 제출/재연습 플로우로 변경

## Backend
- `POST /api/practice/sessions/submit` 추가
- `practice_credit_charge` 엔티티/리포지토리/스키마 하드닝 추가
- `credit_balance` 조건부 차감 쿼리(`deductIfEnough`) 추가
- `topic_selection` 사용자 소유 + 비관적 락 기반 제출 처리
- FK 강건성 보강
  - `practice_credit_charge.topic_selection_id -> topic_selection.id`
  - `practice_credit_charge.user_id -> app_user.id`

## Frontend
- `submitPracticeSession(topicSelectionId)` API 추가
- `/practice/[topicId]` 진입에 `selectionId` 쿼리 필수
- 제출 완료 시 차감 API 호출, 실패 시 요약 화면에 명시적 에러 배너 노출
- 같은 주제 재연습 시 새 selection 생성 후 새 세션 진입

## Tests
- `PracticeSessionServiceTest`
  - 동일 selection 중복 제출 1회 차감
  - 동시 제출 1회 차감
  - 고부하 병렬 제출(서비스 레벨) 1회 차감
  - 서로 다른 selection 동시 제출 + 경계 잔액(2) 음수 미발생
  - 타 사용자 selection 제출 차단
  - 잔액 부족 실패
- `PracticeSessionControllerTest` (정상/402)
- `TopicSelectionControllerTest` 시작 전 잔액 검사

Closes #69