### PR TITLE
refactor(api): apply Light CQRS command/query service split

### DIFF
--- a/opicer-api/src/main/java/com/opicer/api/credit/application/CreditBalanceCommandService.java
+++ b/opicer-api/src/main/java/com/opicer/api/credit/application/CreditBalanceCommandService.java
@@ -9,13 +9,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-public class CreditBalanceService {
+public class CreditBalanceCommandService {
 
-	private static final Logger log = LoggerFactory.getLogger(CreditBalanceService.class);
+	private static final Logger log = LoggerFactory.getLogger(CreditBalanceCommandService.class);
 
 	private final CreditBalanceRepository creditBalanceRepository;
 
-	public CreditBalanceService(CreditBalanceRepository creditBalanceRepository) {
+	public CreditBalanceCommandService(CreditBalanceRepository creditBalanceRepository) {
 		this.creditBalanceRepository = creditBalanceRepository;
 	}
 
@@ -36,20 +36,6 @@ public class CreditBalanceService {
 			created.increase(amount);
 			creditBalanceRepository.save(created);
 		}
-	}
-
-	@Transactional(readOnly = true)
-	public CreditBalance getBalance(UUID userId) {
-		log.debug("Fetching credit balance. userId={}", userId);
-		return creditBalanceRepository.findByUserId(userId)
-			.orElseThrow(() -> new IllegalArgumentException("Balance not found"));
-	}
-
-	@Transactional(readOnly = true)
-	public boolean hasEnough(UUID userId, long amount) {
-		return creditBalanceRepository.findByUserId(userId)
-			.map(balance -> balance.getBalance() >= amount)
-			.orElse(false);
 	}
 
 	@Transactional

--- a/opicer-api/src/main/java/com/opicer/api/credit/application/CreditBalanceQueryService.java
+++ b/opicer-api/src/main/java/com/opicer/api/credit/application/CreditBalanceQueryService.java
@@ -1,0 +1,35 @@
+package com.opicer.api.credit.application;
+
+import com.opicer.api.credit.domain.CreditBalance;
+import com.opicer.api.credit.infrastructure.CreditBalanceRepository;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class CreditBalanceQueryService {
+
+	private static final Logger log = LoggerFactory.getLogger(CreditBalanceQueryService.class);
+
+	private final CreditBalanceRepository creditBalanceRepository;
+
+	public CreditBalanceQueryService(CreditBalanceRepository creditBalanceRepository) {
+		this.creditBalanceRepository = creditBalanceRepository;
+	}
+
+	@Transactional(readOnly = true)
+	public CreditBalance getBalance(UUID userId) {
+		log.debug("Fetching credit balance. userId={}", userId);
+		return creditBalanceRepository.findByUserId(userId)
+			.orElseThrow(() -> new IllegalArgumentException("Balance not found"));
+	}
+
+	@Transactional(readOnly = true)
+	public boolean hasEnough(UUID userId, long amount) {
+		return creditBalanceRepository.findByUserId(userId)
+			.map(balance -> balance.getBalance() >= amount)
+			.orElse(false);
+	}
+}

--- a/opicer-api/src/main/java/com/opicer/api/credit/application/CreditOrderCommandService.java
+++ b/opicer-api/src/main/java/com/opicer/api/credit/application/CreditOrderCommandService.java
@@ -9,32 +9,28 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-public class CreditOrderService {
+public class CreditOrderCommandService {
 
-	private static final Logger log = LoggerFactory.getLogger(CreditOrderService.class);
+	private static final Logger log = LoggerFactory.getLogger(CreditOrderCommandService.class);
 
 	private final CreditOrderRepository creditOrderRepository;
-	private final CreditBalanceService creditBalanceService;
+	private final CreditBalanceCommandService creditBalanceCommandService;
 
-	public CreditOrderService(CreditOrderRepository creditOrderRepository, CreditBalanceService creditBalanceService) {
+	public CreditOrderCommandService(
+		CreditOrderRepository creditOrderRepository,
+		CreditBalanceCommandService creditBalanceCommandService
+	) {
 		this.creditOrderRepository = creditOrderRepository;
-		this.creditBalanceService = creditBalanceService;
+		this.creditBalanceCommandService = creditBalanceCommandService;
 	}
 
 	@Transactional
 	public CreditOrder createOrder(UUID userId, String packageId, int amount) {
 		log.info("Creating credit order. userId={}, packageId={}, amount={}", userId, packageId, amount);
-		creditBalanceService.ensureBalance(userId);
+		creditBalanceCommandService.ensureBalance(userId);
 		CreditOrder order = new CreditOrder(userId, packageId, amount);
 		CreditOrder saved = creditOrderRepository.save(order);
 		log.info("Credit order created. orderId={}, userId={}, status={}", saved.getId(), userId, saved.getStatus());
 		return saved;
-	}
-
-	@Transactional(readOnly = true)
-	public CreditOrder getOrder(UUID orderId) {
-		log.debug("Fetching credit order. orderId={}", orderId);
-		return creditOrderRepository.findById(orderId)
-			.orElseThrow(() -> new IllegalArgumentException("Order not found"));
 	}
 }

--- a/opicer-api/src/main/java/com/opicer/api/credit/application/CreditOrderQueryService.java
+++ b/opicer-api/src/main/java/com/opicer/api/credit/application/CreditOrderQueryService.java
@@ -1,0 +1,28 @@
+package com.opicer.api.credit.application;
+
+import com.opicer.api.credit.domain.CreditOrder;
+import com.opicer.api.credit.infrastructure.CreditOrderRepository;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class CreditOrderQueryService {
+
+	private static final Logger log = LoggerFactory.getLogger(CreditOrderQueryService.class);
+
+	private final CreditOrderRepository creditOrderRepository;
+
+	public CreditOrderQueryService(CreditOrderRepository creditOrderRepository) {
+		this.creditOrderRepository = creditOrderRepository;
+	}
+
+	@Transactional(readOnly = true)
+	public CreditOrder getOrder(UUID orderId) {
+		log.debug("Fetching credit order. orderId={}", orderId);
+		return creditOrderRepository.findById(orderId)
+			.orElseThrow(() -> new IllegalArgumentException("Order not found"));
+	}
+}

--- a/opicer-api/src/main/java/com/opicer/api/credit/application/CreditPaymentService.java
+++ b/opicer-api/src/main/java/com/opicer/api/credit/application/CreditPaymentService.java
@@ -33,36 +33,36 @@ public class CreditPaymentService {
 
 	private static final Logger log = LoggerFactory.getLogger(CreditPaymentService.class);
 
-	private final CreditOrderService creditOrderService;
+	private final CreditOrderQueryService creditOrderQueryService;
 	private final CreditPaymentRepository creditPaymentRepository;
 	private final CreditPaymentIdempotencyRepository creditPaymentIdempotencyRepository;
 	private final MockPaymentRecordRepository mockPaymentRecordRepository;
 	private final CreditProperties creditProperties;
-	private final CreditBalanceService creditBalanceService;
+	private final CreditBalanceCommandService creditBalanceCommandService;
 	private final ObjectMapper objectMapper;
 
 	public CreditPaymentService(
-		CreditOrderService creditOrderService,
+		CreditOrderQueryService creditOrderQueryService,
 		CreditPaymentRepository creditPaymentRepository,
 		CreditPaymentIdempotencyRepository creditPaymentIdempotencyRepository,
 		MockPaymentRecordRepository mockPaymentRecordRepository,
 		CreditProperties creditProperties,
-		CreditBalanceService creditBalanceService,
+		CreditBalanceCommandService creditBalanceCommandService,
 		ObjectMapper objectMapper
 	) {
-		this.creditOrderService = creditOrderService;
+		this.creditOrderQueryService = creditOrderQueryService;
 		this.creditPaymentRepository = creditPaymentRepository;
 		this.creditPaymentIdempotencyRepository = creditPaymentIdempotencyRepository;
 		this.mockPaymentRecordRepository = mockPaymentRecordRepository;
 		this.creditProperties = creditProperties;
-		this.creditBalanceService = creditBalanceService;
+		this.creditBalanceCommandService = creditBalanceCommandService;
 		this.objectMapper = objectMapper;
 	}
 
 	@Transactional
 	public CreditPayment confirmPayment(UUID orderId, String providerTxId) {
 		log.info("Confirming credit payment (vulnerable path). orderId={}, providerTxId={}", orderId, providerTxId);
-		CreditOrder order = creditOrderService.getOrder(orderId);
+		CreditOrder order = creditOrderQueryService.getOrder(orderId);
 		mockPaymentRecordRepository.save(new MockPaymentRecord(providerTxId, MockPaymentDecision.APPROVED));
 
 		// NOTE: INTENTIONALLY VULNERABLE
@@ -74,7 +74,7 @@ public class CreditPaymentService {
 				try {
 					CreditPayment saved = creditPaymentRepository.save(payment);
 					order.markPaid();
-					creditBalanceService.addBalance(order.getUserId(), order.getAmount());
+					creditBalanceCommandService.addBalance(order.getUserId(), order.getAmount());
 					log.info("Credit payment approved. paymentId={}, orderId={}, userId={}",
 						saved.getId(), saved.getOrderId(), order.getUserId());
 					return saved;
@@ -93,7 +93,7 @@ public class CreditPaymentService {
 		if (idempotencyKey == null || idempotencyKey.isBlank()) {
 			throw new ApiException(ErrorCode.VALIDATION_ERROR, "Idempotency-Key header is required");
 		}
-		CreditOrder order = creditOrderService.getOrder(orderId);
+		CreditOrder order = creditOrderQueryService.getOrder(orderId);
 		String requestHash = computeRequestHash(orderId, providerTxId);
 		Instant now = Instant.now();
 		Instant expiresAt = now.plus(creditProperties.getIdempotencyTtlHours(), ChronoUnit.HOURS);

--- a/opicer-api/src/main/java/com/opicer/api/credit/presentation/CreditPurchaseController.java
+++ b/opicer-api/src/main/java/com/opicer/api/credit/presentation/CreditPurchaseController.java
@@ -1,6 +1,6 @@
 package com.opicer.api.credit.presentation;
 
-import com.opicer.api.credit.application.CreditOrderService;
+import com.opicer.api.credit.application.CreditOrderCommandService;
 import com.opicer.api.credit.application.CreditPaymentService;
 import com.opicer.api.credit.domain.CreditOrder;
 import com.opicer.api.credit.domain.CreditPayment;
@@ -24,14 +24,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/credits")
 public class CreditPurchaseController {
 
-	private final CreditOrderService creditOrderService;
+	private final CreditOrderCommandService creditOrderCommandService;
 	private final CreditPaymentService creditPaymentService;
 
 	public CreditPurchaseController(
-		CreditOrderService creditOrderService,
+		CreditOrderCommandService creditOrderCommandService,
 		CreditPaymentService creditPaymentService
 	) {
-		this.creditOrderService = creditOrderService;
+		this.creditOrderCommandService = creditOrderCommandService;
 		this.creditPaymentService = creditPaymentService;
 	}
 
@@ -41,7 +41,7 @@ public class CreditPurchaseController {
 		@Valid @RequestBody OrderRequest request
 	) {
 		UUID currentUserId = resolveCurrentUserId(authentication);
-		CreditOrder order = creditOrderService.createOrder(currentUserId, request.packageId(), request.amount());
+		CreditOrder order = creditOrderCommandService.createOrder(currentUserId, request.packageId(), request.amount());
 		return ResponseEntity.status(201).body(ApiResponse.created("CREDIT_ORDER_CREATED",
 			new OrderResponse(order.getId(), order.getUserId(), order.getPackageId(), order.getAmount(), order.getStatus().name(),
 				order.getCreatedAt())));

--- a/opicer-api/src/main/java/com/opicer/api/dailysentence/application/DailySentenceCommandService.java
+++ b/opicer-api/src/main/java/com/opicer/api/dailysentence/application/DailySentenceCommandService.java
@@ -6,34 +6,18 @@ import com.opicer.api.shared.domain.OpicLevel;
 import com.opicer.api.shared.error.ApiException;
 import com.opicer.api.shared.error.ErrorCode;
 import java.time.LocalDate;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-public class DailySentenceService {
+public class DailySentenceCommandService {
 
 	private final DailySentenceRepository dailySentenceRepository;
 
-	public DailySentenceService(DailySentenceRepository dailySentenceRepository) {
+	public DailySentenceCommandService(DailySentenceRepository dailySentenceRepository) {
 		this.dailySentenceRepository = dailySentenceRepository;
-	}
-
-	@Transactional(readOnly = true)
-	public List<DailySentence> findAll() {
-		return dailySentenceRepository.findAll();
-	}
-
-	@Transactional(readOnly = true)
-	public Optional<DailySentence> findById(UUID id) {
-		return dailySentenceRepository.findById(id);
-	}
-
-	@Transactional(readOnly = true)
-	public Optional<DailySentence> findByDate(LocalDate date) {
-		return dailySentenceRepository.findByDate(date);
 	}
 
 	@Transactional
@@ -65,5 +49,4 @@ public class DailySentenceService {
 		dailySentenceRepository.deleteById(id);
 		return true;
 	}
-
 }

--- a/opicer-api/src/main/java/com/opicer/api/dailysentence/application/DailySentenceQueryService.java
+++ b/opicer-api/src/main/java/com/opicer/api/dailysentence/application/DailySentenceQueryService.java
@@ -1,0 +1,35 @@
+package com.opicer.api.dailysentence.application;
+
+import com.opicer.api.dailysentence.domain.DailySentence;
+import com.opicer.api.dailysentence.infrastructure.DailySentenceRepository;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class DailySentenceQueryService {
+
+	private final DailySentenceRepository dailySentenceRepository;
+
+	public DailySentenceQueryService(DailySentenceRepository dailySentenceRepository) {
+		this.dailySentenceRepository = dailySentenceRepository;
+	}
+
+	@Transactional(readOnly = true)
+	public List<DailySentence> findAll() {
+		return dailySentenceRepository.findAll();
+	}
+
+	@Transactional(readOnly = true)
+	public Optional<DailySentence> findById(UUID id) {
+		return dailySentenceRepository.findById(id);
+	}
+
+	@Transactional(readOnly = true)
+	public Optional<DailySentence> findByDate(LocalDate date) {
+		return dailySentenceRepository.findByDate(date);
+	}
+}

--- a/opicer-api/src/main/java/com/opicer/api/dailysentence/presentation/AdminDailySentenceController.java
+++ b/opicer-api/src/main/java/com/opicer/api/dailysentence/presentation/AdminDailySentenceController.java
@@ -1,6 +1,7 @@
 package com.opicer.api.dailysentence.presentation;
 
-import com.opicer.api.dailysentence.application.DailySentenceService;
+import com.opicer.api.dailysentence.application.DailySentenceCommandService;
+import com.opicer.api.dailysentence.application.DailySentenceQueryService;
 import com.opicer.api.dailysentence.domain.DailySentence;
 import com.opicer.api.shared.domain.OpicLevel;
 import com.opicer.api.shared.error.ApiException;
@@ -27,15 +28,20 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/admin/daily-sentences")
 public class AdminDailySentenceController {
 
-	private final DailySentenceService dailySentenceService;
+	private final DailySentenceQueryService dailySentenceQueryService;
+	private final DailySentenceCommandService dailySentenceCommandService;
 
-	public AdminDailySentenceController(DailySentenceService dailySentenceService) {
-		this.dailySentenceService = dailySentenceService;
+	public AdminDailySentenceController(
+		DailySentenceQueryService dailySentenceQueryService,
+		DailySentenceCommandService dailySentenceCommandService
+	) {
+		this.dailySentenceQueryService = dailySentenceQueryService;
+		this.dailySentenceCommandService = dailySentenceCommandService;
 	}
 
 	@GetMapping
 	public ResponseEntity<ApiResponse<List<DailySentenceResponse>>> list() {
-		List<DailySentenceResponse> sentences = dailySentenceService.findAll().stream()
+		List<DailySentenceResponse> sentences = dailySentenceQueryService.findAll().stream()
 			.map(DailySentenceResponse::from)
 			.toList();
 		return ResponseEntity.ok(ApiResponse.ok("DAILY_SENTENCE_LIST_OK", sentences));
@@ -43,7 +49,7 @@ public class AdminDailySentenceController {
 
 	@PostMapping
 	public ResponseEntity<Object> create(@Valid @RequestBody DailySentenceRequest request) {
-		DailySentence sentence = dailySentenceService.create(
+		DailySentence sentence = dailySentenceCommandService.create(
 			request.date(), request.text(), request.level(), request.audioUrl());
 		return ResponseEntity.status(201)
 			.body(ApiResponse.created("DAILY_SENTENCE_CREATED", DailySentenceResponse.from(sentence)));
@@ -52,7 +58,7 @@ public class AdminDailySentenceController {
 	@PutMapping("/{id}")
 	public ResponseEntity<Object> update(@PathVariable UUID id,
 		@Valid @RequestBody DailySentenceRequest request) {
-		return dailySentenceService.update(id, request.date(), request.text(), request.level(),
+		return dailySentenceCommandService.update(id, request.date(), request.text(), request.level(),
 				request.audioUrl(), request.active() != null ? request.active() : true)
 			.<ResponseEntity<Object>>map(s -> ResponseEntity.ok(
 				ApiResponse.ok("DAILY_SENTENCE_UPDATED", DailySentenceResponse.from(s))))
@@ -63,7 +69,7 @@ public class AdminDailySentenceController {
 
 	@DeleteMapping("/{id}")
 	public ResponseEntity<Object> delete(@PathVariable UUID id) {
-		if (dailySentenceService.delete(id)) {
+		if (dailySentenceCommandService.delete(id)) {
 			return ResponseEntity.ok(ApiResponse.ok("DAILY_SENTENCE_DELETED", null));
 		}
 		throw new ApiException(

--- a/opicer-api/src/main/java/com/opicer/api/goodanswer/application/GoodAnswerSampleCommandService.java
+++ b/opicer-api/src/main/java/com/opicer/api/goodanswer/application/GoodAnswerSampleCommandService.java
@@ -4,11 +4,11 @@ import com.opicer.api.ai.application.AiEmbeddingService;
 import com.opicer.api.ai.application.AiTranscriptionService;
 import com.opicer.api.goodanswer.domain.GoodAnswerSample;
 import com.opicer.api.goodanswer.infrastructure.GoodAnswerSampleRepository;
+import com.opicer.api.shared.domain.OpicLevel;
 import com.opicer.api.shared.error.ApiException;
 import com.opicer.api.shared.error.ErrorCode;
-import com.opicer.api.shared.domain.OpicLevel;
 import com.opicer.api.shared.infrastructure.AudioStorage;
-import com.opicer.api.topic.application.TopicService;
+import com.opicer.api.topic.application.TopicQueryService;
 import com.opicer.api.topic.domain.Topic;
 import java.util.List;
 import java.util.UUID;
@@ -17,23 +17,23 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
-public class GoodAnswerSampleService {
+public class GoodAnswerSampleCommandService {
 
 	private final GoodAnswerSampleRepository repository;
-	private final TopicService topicService;
+	private final TopicQueryService topicQueryService;
 	private final AiEmbeddingService embeddingService;
 	private final AudioStorage audioStorage;
 	private final AiTranscriptionService transcriptionService;
 
-	public GoodAnswerSampleService(
+	public GoodAnswerSampleCommandService(
 		GoodAnswerSampleRepository repository,
-		TopicService topicService,
+		TopicQueryService topicQueryService,
 		AiEmbeddingService embeddingService,
 		AudioStorage audioStorage,
 		AiTranscriptionService transcriptionService
 	) {
 		this.repository = repository;
-		this.topicService = topicService;
+		this.topicQueryService = topicQueryService;
 		this.embeddingService = embeddingService;
 		this.audioStorage = audioStorage;
 		this.transcriptionService = transcriptionService;
@@ -42,7 +42,7 @@ public class GoodAnswerSampleService {
 	@Transactional
 	public GoodAnswerSample create(UUID topicId, OpicLevel level, String sampleText, String sampleAudioUrl,
 		String summary, List<String> tags, List<String> keyExpressions) {
-		Topic topic = topicService.getActiveOrThrow(topicId);
+		Topic topic = topicQueryService.getActiveOrThrow(topicId);
 		float[] embedding = embeddingService.embed(sampleText);
 		GoodAnswerSample sample = new GoodAnswerSample(
 			topic, level, sampleText, sampleAudioUrl, summary, tags, keyExpressions, embedding
@@ -68,36 +68,8 @@ public class GoodAnswerSampleService {
 			.toList();
 	}
 
-	@Transactional(readOnly = true)
-	public List<GoodAnswerSample> listByTopic(UUID topicId) {
-		return repository.findByTopicId(topicId);
-	}
-
 	@Transactional
 	public void delete(UUID id) {
 		repository.deleteById(id);
-	}
-
-	@Transactional(readOnly = true)
-	public List<GoodAnswerSample> findSimilar(
-		UUID topicId,
-		String transcript,
-		int limit,
-		String questionType,
-		OpicLevel targetLevel
-	) {
-		try {
-			float[] embedding = embeddingService.embed(transcript);
-			List<GoodAnswerSample> filtered = repository.findSimilar(topicId, embedding, limit, questionType, targetLevel);
-			if (!filtered.isEmpty() || (questionType == null && targetLevel == null)) {
-				return filtered;
-			}
-			// Fallback: if strict metadata filtering yields no rows, return similarity-only result.
-			return repository.findSimilar(topicId, embedding, limit, null, null);
-		} catch (ApiException e) {
-			throw e;
-		} catch (Exception e) {
-			throw new ApiException(ErrorCode.AI_RAG_FAILED, e.getMessage());
-		}
 	}
 }

--- a/opicer-api/src/main/java/com/opicer/api/goodanswer/application/GoodAnswerSampleQueryService.java
+++ b/opicer-api/src/main/java/com/opicer/api/goodanswer/application/GoodAnswerSampleQueryService.java
@@ -1,0 +1,54 @@
+package com.opicer.api.goodanswer.application;
+
+import com.opicer.api.ai.application.AiEmbeddingService;
+import com.opicer.api.goodanswer.domain.GoodAnswerSample;
+import com.opicer.api.goodanswer.infrastructure.GoodAnswerSampleRepository;
+import com.opicer.api.shared.domain.OpicLevel;
+import com.opicer.api.shared.error.ApiException;
+import com.opicer.api.shared.error.ErrorCode;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class GoodAnswerSampleQueryService {
+
+	private final GoodAnswerSampleRepository repository;
+	private final AiEmbeddingService embeddingService;
+
+	public GoodAnswerSampleQueryService(
+		GoodAnswerSampleRepository repository,
+		AiEmbeddingService embeddingService
+	) {
+		this.repository = repository;
+		this.embeddingService = embeddingService;
+	}
+
+	@Transactional(readOnly = true)
+	public List<GoodAnswerSample> listByTopic(UUID topicId) {
+		return repository.findByTopicId(topicId);
+	}
+
+	@Transactional(readOnly = true)
+	public List<GoodAnswerSample> findSimilar(
+		UUID topicId,
+		String transcript,
+		int limit,
+		String questionType,
+		OpicLevel targetLevel
+	) {
+		try {
+			float[] embedding = embeddingService.embed(transcript);
+			List<GoodAnswerSample> filtered = repository.findSimilar(topicId, embedding, limit, questionType, targetLevel);
+			if (!filtered.isEmpty() || (questionType == null && targetLevel == null)) {
+				return filtered;
+			}
+			return repository.findSimilar(topicId, embedding, limit, null, null);
+		} catch (ApiException e) {
+			throw e;
+		} catch (Exception e) {
+			throw new ApiException(ErrorCode.AI_RAG_FAILED, e.getMessage());
+		}
+	}
+}

--- a/opicer-api/src/main/java/com/opicer/api/goodanswer/presentation/AdminGoodAnswerSampleController.java
+++ b/opicer-api/src/main/java/com/opicer/api/goodanswer/presentation/AdminGoodAnswerSampleController.java
@@ -1,6 +1,7 @@
 package com.opicer.api.goodanswer.presentation;
 
-import com.opicer.api.goodanswer.application.GoodAnswerSampleService;
+import com.opicer.api.goodanswer.application.GoodAnswerSampleCommandService;
+import com.opicer.api.goodanswer.application.GoodAnswerSampleQueryService;
 import com.opicer.api.goodanswer.domain.GoodAnswerSample;
 import com.opicer.api.shared.domain.OpicLevel;
 import com.opicer.api.shared.presentation.ApiResponse;
@@ -27,15 +28,20 @@ import org.springframework.web.multipart.MultipartFile;
 @RequestMapping("/api/admin/good-answers")
 public class AdminGoodAnswerSampleController {
 
-	private final GoodAnswerSampleService service;
+	private final GoodAnswerSampleCommandService goodAnswerSampleCommandService;
+	private final GoodAnswerSampleQueryService goodAnswerSampleQueryService;
 
-	public AdminGoodAnswerSampleController(GoodAnswerSampleService service) {
-		this.service = service;
+	public AdminGoodAnswerSampleController(
+		GoodAnswerSampleCommandService goodAnswerSampleCommandService,
+		GoodAnswerSampleQueryService goodAnswerSampleQueryService
+	) {
+		this.goodAnswerSampleCommandService = goodAnswerSampleCommandService;
+		this.goodAnswerSampleQueryService = goodAnswerSampleQueryService;
 	}
 
 	@PostMapping
 	public ApiResponse<Map<String, Object>> create(@Valid @RequestBody CreateRequest request) {
-		GoodAnswerSample sample = service.create(
+		GoodAnswerSample sample = goodAnswerSampleCommandService.create(
 			request.topicId(),
 			request.level(),
 			request.sampleText(),
@@ -60,7 +66,7 @@ public class AdminGoodAnswerSampleController {
 		@RequestParam(required = false) String tags,
 		@RequestParam(required = false) String keyExpressions
 	) {
-		List<GoodAnswerSample> samples = service.createFromAudio(
+		List<GoodAnswerSample> samples = goodAnswerSampleCommandService.createFromAudio(
 			topicId,
 			level,
 			audio,
@@ -82,7 +88,7 @@ public class AdminGoodAnswerSampleController {
 
 	@GetMapping
 	public ApiResponse<List<GoodAnswerSampleResponse>> list(@RequestParam UUID topicId) {
-		List<GoodAnswerSampleResponse> result = service.listByTopic(topicId).stream()
+		List<GoodAnswerSampleResponse> result = goodAnswerSampleQueryService.listByTopic(topicId).stream()
 			.map(GoodAnswerSampleResponse::from)
 			.toList();
 		return ApiResponse.ok("Good answer samples", result);
@@ -90,7 +96,7 @@ public class AdminGoodAnswerSampleController {
 
 	@DeleteMapping("/{id}")
 	public ApiResponse<Void> delete(@PathVariable UUID id) {
-		service.delete(id);
+		goodAnswerSampleCommandService.delete(id);
 		return ApiResponse.ok("Good answer sample deleted", null);
 	}
 

--- a/opicer-api/src/main/java/com/opicer/api/practice/application/PracticeAiService.java
+++ b/opicer-api/src/main/java/com/opicer/api/practice/application/PracticeAiService.java
@@ -2,10 +2,10 @@ package com.opicer.api.practice.application;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.opicer.api.config.AiProperties;
-import com.opicer.api.prompt.application.PromptVersionService;
+import com.opicer.api.prompt.application.PromptVersionQueryService;
 import com.opicer.api.prompt.domain.PromptUseCase;
 import com.opicer.api.prompt.domain.PromptVersion;
-import com.opicer.api.goodanswer.application.GoodAnswerSampleService;
+import com.opicer.api.goodanswer.application.GoodAnswerSampleQueryService;
 import com.opicer.api.goodanswer.domain.GoodAnswerSample;
 import com.opicer.api.shared.domain.OpicLevel;
 import com.opicer.api.shared.error.ApiException;
@@ -44,18 +44,18 @@ public class PracticeAiService {
 		"Return ONLY the improved script. Target IL~IM level.";
 
 	private final AiProperties aiProperties;
-	private final PromptVersionService promptVersionService;
-	private final GoodAnswerSampleService goodAnswerSampleService;
+	private final PromptVersionQueryService promptVersionQueryService;
+	private final GoodAnswerSampleQueryService goodAnswerSampleQueryService;
 	private final RestClient restClient;
 
 	public PracticeAiService(
 		AiProperties aiProperties,
-		PromptVersionService promptVersionService,
-		GoodAnswerSampleService goodAnswerSampleService
+		PromptVersionQueryService promptVersionQueryService,
+		GoodAnswerSampleQueryService goodAnswerSampleQueryService
 	) {
 		this.aiProperties = aiProperties;
-		this.promptVersionService = promptVersionService;
-		this.goodAnswerSampleService = goodAnswerSampleService;
+		this.promptVersionQueryService = promptVersionQueryService;
+		this.goodAnswerSampleQueryService = goodAnswerSampleQueryService;
 		this.restClient = RestClient.create();
 	}
 
@@ -97,7 +97,7 @@ public class PracticeAiService {
 		if (apiKey == null || apiKey.isBlank()) {
 			throw new ApiException(ErrorCode.AI_NOT_CONFIGURED);
 		}
-		String template = promptVersionService.findActiveByUseCase(PromptUseCase.FEEDBACK)
+		String template = promptVersionQueryService.findActiveByUseCase(PromptUseCase.FEEDBACK)
 			.map(PromptVersion::getTemplate)
 			.orElse(DEFAULT_FEEDBACK_TEMPLATE);
 		String prompt = template
@@ -118,7 +118,7 @@ public class PracticeAiService {
 		if (apiKey == null || apiKey.isBlank()) {
 			throw new ApiException(ErrorCode.AI_NOT_CONFIGURED);
 		}
-		String template = promptVersionService.findActiveByUseCase(PromptUseCase.SCRIPT_IMPROVEMENT)
+		String template = promptVersionQueryService.findActiveByUseCase(PromptUseCase.SCRIPT_IMPROVEMENT)
 			.map(PromptVersion::getTemplate)
 			.orElse(DEFAULT_SCRIPT_IMPROVEMENT_TEMPLATE);
 		String prompt = template
@@ -135,7 +135,7 @@ public class PracticeAiService {
 		String questionType,
 		OpicLevel targetLevel
 	) {
-		List<GoodAnswerSample> samples = goodAnswerSampleService.findSimilar(
+		List<GoodAnswerSample> samples = goodAnswerSampleQueryService.findSimilar(
 			topicId,
 			transcript,
 			3,

--- a/opicer-api/src/main/java/com/opicer/api/practice/application/PracticeSessionCommandService.java
+++ b/opicer-api/src/main/java/com/opicer/api/practice/application/PracticeSessionCommandService.java
@@ -1,6 +1,6 @@
 package com.opicer.api.practice.application;
 
-import com.opicer.api.credit.application.CreditBalanceService;
+import com.opicer.api.credit.application.CreditBalanceCommandService;
 import com.opicer.api.practice.domain.PracticeCreditCharge;
 import com.opicer.api.practice.domain.TopicSelection;
 import com.opicer.api.practice.infrastructure.PracticeCreditChargeRepository;
@@ -12,22 +12,22 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-public class PracticeSessionService {
+public class PracticeSessionCommandService {
 
 	private static final int PRACTICE_COST = 2;
 
 	private final TopicSelectionRepository topicSelectionRepository;
 	private final PracticeCreditChargeRepository practiceCreditChargeRepository;
-	private final CreditBalanceService creditBalanceService;
+	private final CreditBalanceCommandService creditBalanceCommandService;
 
-	public PracticeSessionService(
+	public PracticeSessionCommandService(
 		TopicSelectionRepository topicSelectionRepository,
 		PracticeCreditChargeRepository practiceCreditChargeRepository,
-		CreditBalanceService creditBalanceService
+		CreditBalanceCommandService creditBalanceCommandService
 	) {
 		this.topicSelectionRepository = topicSelectionRepository;
 		this.practiceCreditChargeRepository = practiceCreditChargeRepository;
-		this.creditBalanceService = creditBalanceService;
+		this.creditBalanceCommandService = creditBalanceCommandService;
 	}
 
 	@Transactional
@@ -41,7 +41,7 @@ public class PracticeSessionService {
 			return new SubmitResult(existing.getId(), true, existing.getAmount());
 		}
 
-		boolean deducted = creditBalanceService.deductIfEnough(userId, PRACTICE_COST);
+		boolean deducted = creditBalanceCommandService.deductIfEnough(userId, PRACTICE_COST);
 		if (!deducted) {
 			throw new ApiException(ErrorCode.CREDIT_INSUFFICIENT_BALANCE, "At least 2 credits are required to submit practice");
 		}

--- a/opicer-api/src/main/java/com/opicer/api/practice/application/TopicSelectionCommandService.java
+++ b/opicer-api/src/main/java/com/opicer/api/practice/application/TopicSelectionCommandService.java
@@ -1,39 +1,39 @@
 package com.opicer.api.practice.application;
 
-import com.opicer.api.credit.application.CreditBalanceService;
+import com.opicer.api.credit.application.CreditBalanceQueryService;
 import com.opicer.api.practice.domain.TopicSelection;
 import com.opicer.api.practice.infrastructure.TopicSelectionRepository;
 import com.opicer.api.shared.error.ApiException;
 import com.opicer.api.shared.error.ErrorCode;
-import com.opicer.api.topic.application.TopicService;
+import com.opicer.api.topic.application.TopicQueryService;
 import com.opicer.api.topic.domain.Topic;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-public class TopicSelectionService {
+public class TopicSelectionCommandService {
 
 	private final TopicSelectionRepository topicSelectionRepository;
-	private final TopicService topicService;
-	private final CreditBalanceService creditBalanceService;
+	private final TopicQueryService topicQueryService;
+	private final CreditBalanceQueryService creditBalanceQueryService;
 
-	public TopicSelectionService(
+	public TopicSelectionCommandService(
 		TopicSelectionRepository topicSelectionRepository,
-		TopicService topicService,
-		CreditBalanceService creditBalanceService
+		TopicQueryService topicQueryService,
+		CreditBalanceQueryService creditBalanceQueryService
 	) {
 		this.topicSelectionRepository = topicSelectionRepository;
-		this.topicService = topicService;
-		this.creditBalanceService = creditBalanceService;
+		this.topicQueryService = topicQueryService;
+		this.creditBalanceQueryService = creditBalanceQueryService;
 	}
 
 	@Transactional
 	public TopicSelection createSelection(UUID userId, UUID topicId) {
-		if (!creditBalanceService.hasEnough(userId, 2)) {
+		if (!creditBalanceQueryService.hasEnough(userId, 2)) {
 			throw new ApiException(ErrorCode.CREDIT_INSUFFICIENT_BALANCE, "At least 2 credits are required to start practice");
 		}
-		Topic topic = topicService.getActiveOrThrow(topicId);
+		Topic topic = topicQueryService.getActiveOrThrow(topicId);
 		TopicSelection selection = new TopicSelection(userId, topic.getId());
 		return topicSelectionRepository.save(selection);
 	}

--- a/opicer-api/src/main/java/com/opicer/api/practice/presentation/PracticeQuestionController.java
+++ b/opicer-api/src/main/java/com/opicer/api/practice/presentation/PracticeQuestionController.java
@@ -1,11 +1,11 @@
 package com.opicer.api.practice.presentation;
 
-import com.opicer.api.question.application.QuestionService;
+import com.opicer.api.question.application.QuestionQueryService;
 import com.opicer.api.question.domain.Question;
 import com.opicer.api.question.domain.QuestionType;
 import com.opicer.api.shared.domain.OpicLevel;
 import com.opicer.api.shared.presentation.ApiResponse;
-import com.opicer.api.topic.application.TopicService;
+import com.opicer.api.topic.application.TopicQueryService;
 import com.opicer.api.topic.domain.Topic;
 import java.time.Instant;
 import java.util.List;
@@ -20,18 +20,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/practice/topics")
 public class PracticeQuestionController {
 
-	private final TopicService topicService;
-	private final QuestionService questionService;
+	private final TopicQueryService topicQueryService;
+	private final QuestionQueryService questionQueryService;
 
-	public PracticeQuestionController(TopicService topicService, QuestionService questionService) {
-		this.topicService = topicService;
-		this.questionService = questionService;
+	public PracticeQuestionController(TopicQueryService topicQueryService, QuestionQueryService questionQueryService) {
+		this.topicQueryService = topicQueryService;
+		this.questionQueryService = questionQueryService;
 	}
 
 	@GetMapping("/{topicId}/questions")
 	public ResponseEntity<ApiResponse<List<QuestionResponse>>> list(@PathVariable UUID topicId) {
-		Topic topic = topicService.getActiveOrThrow(topicId);
-		List<QuestionResponse> questions = questionService.findActiveByTopic(topic.getTitle()).stream()
+		Topic topic = topicQueryService.getActiveOrThrow(topicId);
+		List<QuestionResponse> questions = questionQueryService.findActiveByTopic(topic.getTitle()).stream()
 			.map(QuestionResponse::from)
 			.toList();
 		return ResponseEntity.ok(ApiResponse.ok("PRACTICE_QUESTION_LIST_OK", questions));

--- a/opicer-api/src/main/java/com/opicer/api/practice/presentation/PracticeSessionController.java
+++ b/opicer-api/src/main/java/com/opicer/api/practice/presentation/PracticeSessionController.java
@@ -1,7 +1,7 @@
 package com.opicer.api.practice.presentation;
 
 import com.opicer.api.auth.domain.AuthUserPrincipal;
-import com.opicer.api.practice.application.PracticeSessionService;
+import com.opicer.api.practice.application.PracticeSessionCommandService;
 import com.opicer.api.shared.presentation.ApiResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
@@ -17,10 +17,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/practice/sessions")
 public class PracticeSessionController {
 
-	private final PracticeSessionService practiceSessionService;
+	private final PracticeSessionCommandService practiceSessionCommandService;
 
-	public PracticeSessionController(PracticeSessionService practiceSessionService) {
-		this.practiceSessionService = practiceSessionService;
+	public PracticeSessionController(PracticeSessionCommandService practiceSessionCommandService) {
+		this.practiceSessionCommandService = practiceSessionCommandService;
 	}
 
 	@PostMapping("/submit")
@@ -31,7 +31,7 @@ public class PracticeSessionController {
 		if (authentication == null || !(authentication.getPrincipal() instanceof AuthUserPrincipal principal)) {
 			return ResponseEntity.status(401).build();
 		}
-		PracticeSessionService.SubmitResult result = practiceSessionService.submit(principal.id(), request.topicSelectionId());
+		PracticeSessionCommandService.SubmitResult result = practiceSessionCommandService.submit(principal.id(), request.topicSelectionId());
 		return ResponseEntity.ok(ApiResponse.ok("PRACTICE_SUBMITTED", new SubmitResponse(
 			result.chargeId(),
 			result.alreadyCharged(),

--- a/opicer-api/src/main/java/com/opicer/api/practice/presentation/TopicSelectionController.java
+++ b/opicer-api/src/main/java/com/opicer/api/practice/presentation/TopicSelectionController.java
@@ -1,7 +1,7 @@
 package com.opicer.api.practice.presentation;
 
 import com.opicer.api.auth.domain.AuthUserPrincipal;
-import com.opicer.api.practice.application.TopicSelectionService;
+import com.opicer.api.practice.application.TopicSelectionCommandService;
 import com.opicer.api.practice.domain.TopicSelection;
 import com.opicer.api.shared.presentation.ApiResponse;
 import jakarta.validation.Valid;
@@ -19,10 +19,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/practice/topic-selections")
 public class TopicSelectionController {
 
-	private final TopicSelectionService topicSelectionService;
+	private final TopicSelectionCommandService topicSelectionCommandService;
 
-	public TopicSelectionController(TopicSelectionService topicSelectionService) {
-		this.topicSelectionService = topicSelectionService;
+	public TopicSelectionController(TopicSelectionCommandService topicSelectionCommandService) {
+		this.topicSelectionCommandService = topicSelectionCommandService;
 	}
 
 	@PostMapping
@@ -33,7 +33,7 @@ public class TopicSelectionController {
 		if (authentication == null || !(authentication.getPrincipal() instanceof AuthUserPrincipal principal)) {
 			return ResponseEntity.status(401).build();
 		}
-		TopicSelection selection = topicSelectionService.createSelection(principal.id(), request.topicId());
+		TopicSelection selection = topicSelectionCommandService.createSelection(principal.id(), request.topicId());
 		return ResponseEntity.status(201).body(ApiResponse.created("TOPIC_SELECTION_CREATED",
 			TopicSelectionResponse.from(selection)));
 	}

--- a/opicer-api/src/main/java/com/opicer/api/prompt/application/PromptVersionCommandService.java
+++ b/opicer-api/src/main/java/com/opicer/api/prompt/application/PromptVersionCommandService.java
@@ -3,34 +3,18 @@ package com.opicer.api.prompt.application;
 import com.opicer.api.prompt.domain.PromptUseCase;
 import com.opicer.api.prompt.domain.PromptVersion;
 import com.opicer.api.prompt.infrastructure.PromptVersionRepository;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-public class PromptVersionService {
+public class PromptVersionCommandService {
 
 	private final PromptVersionRepository promptVersionRepository;
 
-	public PromptVersionService(PromptVersionRepository promptVersionRepository) {
+	public PromptVersionCommandService(PromptVersionRepository promptVersionRepository) {
 		this.promptVersionRepository = promptVersionRepository;
-	}
-
-	@Transactional(readOnly = true)
-	public List<PromptVersion> findAll() {
-		return promptVersionRepository.findAll();
-	}
-
-	@Transactional(readOnly = true)
-	public Optional<PromptVersion> findById(UUID id) {
-		return promptVersionRepository.findById(id);
-	}
-
-	@Transactional(readOnly = true)
-	public Optional<PromptVersion> findActiveByUseCase(PromptUseCase useCase) {
-		return promptVersionRepository.findByUseCaseAndActiveTrue(useCase);
 	}
 
 	@Transactional
@@ -48,10 +32,6 @@ public class PromptVersionService {
 		});
 	}
 
-	/**
-	 * Ensures only one active PromptVersion per useCase.
-	 * Deactivates all others in the same useCase before activating this one.
-	 */
 	@Transactional
 	public Optional<PromptVersion> activate(UUID id) {
 		return promptVersionRepository.findById(id).map(promptVersion -> {

--- a/opicer-api/src/main/java/com/opicer/api/prompt/application/PromptVersionQueryService.java
+++ b/opicer-api/src/main/java/com/opicer/api/prompt/application/PromptVersionQueryService.java
@@ -1,0 +1,35 @@
+package com.opicer.api.prompt.application;
+
+import com.opicer.api.prompt.domain.PromptUseCase;
+import com.opicer.api.prompt.domain.PromptVersion;
+import com.opicer.api.prompt.infrastructure.PromptVersionRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class PromptVersionQueryService {
+
+	private final PromptVersionRepository promptVersionRepository;
+
+	public PromptVersionQueryService(PromptVersionRepository promptVersionRepository) {
+		this.promptVersionRepository = promptVersionRepository;
+	}
+
+	@Transactional(readOnly = true)
+	public List<PromptVersion> findAll() {
+		return promptVersionRepository.findAll();
+	}
+
+	@Transactional(readOnly = true)
+	public Optional<PromptVersion> findById(UUID id) {
+		return promptVersionRepository.findById(id);
+	}
+
+	@Transactional(readOnly = true)
+	public Optional<PromptVersion> findActiveByUseCase(PromptUseCase useCase) {
+		return promptVersionRepository.findByUseCaseAndActiveTrue(useCase);
+	}
+}

--- a/opicer-api/src/main/java/com/opicer/api/prompt/presentation/AdminPromptVersionController.java
+++ b/opicer-api/src/main/java/com/opicer/api/prompt/presentation/AdminPromptVersionController.java
@@ -1,6 +1,7 @@
 package com.opicer.api.prompt.presentation;
 
-import com.opicer.api.prompt.application.PromptVersionService;
+import com.opicer.api.prompt.application.PromptVersionCommandService;
+import com.opicer.api.prompt.application.PromptVersionQueryService;
 import com.opicer.api.prompt.domain.PromptUseCase;
 import com.opicer.api.prompt.domain.PromptVersion;
 import com.opicer.api.shared.error.ApiException;
@@ -27,15 +28,20 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/admin/prompts")
 public class AdminPromptVersionController {
 
-	private final PromptVersionService promptVersionService;
+	private final PromptVersionQueryService promptVersionQueryService;
+	private final PromptVersionCommandService promptVersionCommandService;
 
-	public AdminPromptVersionController(PromptVersionService promptVersionService) {
-		this.promptVersionService = promptVersionService;
+	public AdminPromptVersionController(
+		PromptVersionQueryService promptVersionQueryService,
+		PromptVersionCommandService promptVersionCommandService
+	) {
+		this.promptVersionQueryService = promptVersionQueryService;
+		this.promptVersionCommandService = promptVersionCommandService;
 	}
 
 	@GetMapping
 	public ResponseEntity<ApiResponse<List<PromptVersionResponse>>> list() {
-		List<PromptVersionResponse> versions = promptVersionService.findAll().stream()
+		List<PromptVersionResponse> versions = promptVersionQueryService.findAll().stream()
 			.map(PromptVersionResponse::from)
 			.toList();
 		return ResponseEntity.ok(ApiResponse.ok("PROMPT_LIST_OK", versions));
@@ -43,7 +49,7 @@ public class AdminPromptVersionController {
 
 	@PostMapping
 	public ResponseEntity<ApiResponse<PromptVersionResponse>> create(@Valid @RequestBody PromptVersionRequest request) {
-		PromptVersion version = promptVersionService.create(
+		PromptVersion version = promptVersionCommandService.create(
 			request.useCase(), request.version(), request.name(), request.template());
 		return ResponseEntity.status(201)
 			.body(ApiResponse.created("PROMPT_CREATED", PromptVersionResponse.from(version)));
@@ -52,7 +58,7 @@ public class AdminPromptVersionController {
 	@PutMapping("/{id}")
 	public ResponseEntity<Object> update(@PathVariable UUID id,
 		@Valid @RequestBody PromptVersionRequest request) {
-		return promptVersionService.update(id, request.useCase(), request.version(),
+		return promptVersionCommandService.update(id, request.useCase(), request.version(),
 				request.name(), request.template())
 			.<ResponseEntity<Object>>map(v -> ResponseEntity.ok(
 				ApiResponse.ok("PROMPT_UPDATED", PromptVersionResponse.from(v))))
@@ -62,7 +68,7 @@ public class AdminPromptVersionController {
 
 	@PostMapping("/{id}/activate")
 	public ResponseEntity<Object> activate(@PathVariable UUID id) {
-		return promptVersionService.activate(id)
+		return promptVersionCommandService.activate(id)
 			.<ResponseEntity<Object>>map(v -> ResponseEntity.ok(
 				ApiResponse.ok("PROMPT_ACTIVATED", PromptVersionResponse.from(v))))
 			.orElseThrow(() -> new ApiException(
@@ -71,7 +77,7 @@ public class AdminPromptVersionController {
 
 	@DeleteMapping("/{id}")
 	public ResponseEntity<Object> delete(@PathVariable UUID id) {
-		if (promptVersionService.delete(id)) {
+		if (promptVersionCommandService.delete(id)) {
 			return ResponseEntity.ok(ApiResponse.ok("PROMPT_DELETED", null));
 		}
 		throw new ApiException(ErrorCode.PROMPT_NOT_FOUND, "PromptVersion not found: " + id);

--- a/opicer-api/src/main/java/com/opicer/api/question/application/QuestionCommandService.java
+++ b/opicer-api/src/main/java/com/opicer/api/question/application/QuestionCommandService.java
@@ -11,27 +11,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-public class QuestionService {
+public class QuestionCommandService {
 
 	private final QuestionRepository questionRepository;
 
-	public QuestionService(QuestionRepository questionRepository) {
+	public QuestionCommandService(QuestionRepository questionRepository) {
 		this.questionRepository = questionRepository;
-	}
-
-	@Transactional(readOnly = true)
-	public List<Question> findAll() {
-		return questionRepository.findAll();
-	}
-
-	@Transactional(readOnly = true)
-	public List<Question> findActiveByTopic(String topic) {
-		return questionRepository.findByActiveTrueAndTopicOrderByCreatedAtAscIdAsc(topic);
-	}
-
-	@Transactional(readOnly = true)
-	public Optional<Question> findById(UUID id) {
-		return questionRepository.findById(id);
 	}
 
 	@Transactional

--- a/opicer-api/src/main/java/com/opicer/api/question/application/QuestionQueryService.java
+++ b/opicer-api/src/main/java/com/opicer/api/question/application/QuestionQueryService.java
@@ -1,0 +1,34 @@
+package com.opicer.api.question.application;
+
+import com.opicer.api.question.domain.Question;
+import com.opicer.api.question.infrastructure.QuestionRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class QuestionQueryService {
+
+	private final QuestionRepository questionRepository;
+
+	public QuestionQueryService(QuestionRepository questionRepository) {
+		this.questionRepository = questionRepository;
+	}
+
+	@Transactional(readOnly = true)
+	public List<Question> findAll() {
+		return questionRepository.findAll();
+	}
+
+	@Transactional(readOnly = true)
+	public List<Question> findActiveByTopic(String topic) {
+		return questionRepository.findByActiveTrueAndTopicOrderByCreatedAtAscIdAsc(topic);
+	}
+
+	@Transactional(readOnly = true)
+	public Optional<Question> findById(UUID id) {
+		return questionRepository.findById(id);
+	}
+}

--- a/opicer-api/src/main/java/com/opicer/api/question/presentation/AdminQuestionController.java
+++ b/opicer-api/src/main/java/com/opicer/api/question/presentation/AdminQuestionController.java
@@ -1,6 +1,7 @@
 package com.opicer.api.question.presentation;
 
-import com.opicer.api.question.application.QuestionService;
+import com.opicer.api.question.application.QuestionCommandService;
+import com.opicer.api.question.application.QuestionQueryService;
 import com.opicer.api.question.domain.Question;
 import com.opicer.api.question.domain.QuestionType;
 import com.opicer.api.shared.domain.OpicLevel;
@@ -27,15 +28,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/admin/questions")
 public class AdminQuestionController {
 
-	private final QuestionService questionService;
+	private final QuestionQueryService questionQueryService;
+	private final QuestionCommandService questionCommandService;
 
-	public AdminQuestionController(QuestionService questionService) {
-		this.questionService = questionService;
+	public AdminQuestionController(QuestionQueryService questionQueryService, QuestionCommandService questionCommandService) {
+		this.questionQueryService = questionQueryService;
+		this.questionCommandService = questionCommandService;
 	}
 
 	@GetMapping
 	public ResponseEntity<ApiResponse<List<QuestionResponse>>> list() {
-		List<QuestionResponse> questions = questionService.findAll().stream()
+		List<QuestionResponse> questions = questionQueryService.findAll().stream()
 			.map(QuestionResponse::from)
 			.toList();
 		return ResponseEntity.ok(ApiResponse.ok("QUESTION_LIST_OK", questions));
@@ -43,7 +46,7 @@ public class AdminQuestionController {
 
 	@PostMapping
 	public ResponseEntity<ApiResponse<QuestionResponse>> create(@Valid @RequestBody QuestionRequest request) {
-		Question question = questionService.create(
+		Question question = questionCommandService.create(
 			request.topic(), request.type(), request.promptText(), request.promptAudioUrl(),
 			request.structuralHint(), request.targetLevels(), request.keyExpressions());
 		return ResponseEntity.status(201)
@@ -52,7 +55,7 @@ public class AdminQuestionController {
 
 	@PutMapping("/{id}")
 	public ResponseEntity<Object> update(@PathVariable UUID id, @Valid @RequestBody QuestionRequest request) {
-		return questionService.update(id, request.topic(), request.type(), request.promptText(),
+		return questionCommandService.update(id, request.topic(), request.type(), request.promptText(),
 				request.promptAudioUrl(), request.structuralHint(), request.targetLevels(),
 				request.keyExpressions(), request.active() != null ? request.active() : true)
 			.<ResponseEntity<Object>>map(q -> ResponseEntity.ok(
@@ -63,7 +66,7 @@ public class AdminQuestionController {
 
 	@DeleteMapping("/{id}")
 	public ResponseEntity<Object> delete(@PathVariable UUID id) {
-		if (questionService.delete(id)) {
+		if (questionCommandService.delete(id)) {
 			return ResponseEntity.ok(ApiResponse.ok("QUESTION_DELETED", null));
 		}
 		throw new ApiException(ErrorCode.QUESTION_NOT_FOUND, "Question not found: " + id);

--- a/opicer-api/src/main/java/com/opicer/api/topic/application/TopicCommandService.java
+++ b/opicer-api/src/main/java/com/opicer/api/topic/application/TopicCommandService.java
@@ -1,0 +1,46 @@
+package com.opicer.api.topic.application;
+
+import com.opicer.api.topic.domain.Topic;
+import com.opicer.api.topic.domain.TopicBadge;
+import com.opicer.api.topic.infrastructure.TopicRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class TopicCommandService {
+
+	private final TopicRepository topicRepository;
+
+	public TopicCommandService(TopicRepository topicRepository) {
+		this.topicRepository = topicRepository;
+	}
+
+	@Transactional
+	public Topic create(String title, String englishTitle, String category, int categoryOrder, int topicOrder,
+		List<TopicBadge> badges, boolean active) {
+		Topic topic = new Topic(title, englishTitle, category, categoryOrder, topicOrder, badges, active);
+		return topicRepository.save(topic);
+	}
+
+	@Transactional
+	public Optional<Topic> update(UUID id, String title, String englishTitle, String category, int categoryOrder,
+		int topicOrder, List<TopicBadge> badges, boolean active) {
+		return topicRepository.findById(id)
+			.map(existing -> {
+				existing.update(title, englishTitle, category, categoryOrder, topicOrder, badges, active);
+				return topicRepository.save(existing);
+			});
+	}
+
+	@Transactional
+	public boolean delete(UUID id) {
+		if (!topicRepository.existsById(id)) {
+			return false;
+		}
+		topicRepository.deleteById(id);
+		return true;
+	}
+}

--- a/opicer-api/src/main/java/com/opicer/api/topic/application/TopicQueryService.java
+++ b/opicer-api/src/main/java/com/opicer/api/topic/application/TopicQueryService.java
@@ -3,20 +3,18 @@ package com.opicer.api.topic.application;
 import com.opicer.api.shared.error.ApiException;
 import com.opicer.api.shared.error.ErrorCode;
 import com.opicer.api.topic.domain.Topic;
-import com.opicer.api.topic.domain.TopicBadge;
 import com.opicer.api.topic.infrastructure.TopicRepository;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-public class TopicService {
+public class TopicQueryService {
 
 	private final TopicRepository topicRepository;
 
-	public TopicService(TopicRepository topicRepository) {
+	public TopicQueryService(TopicRepository topicRepository) {
 		this.topicRepository = topicRepository;
 	}
 
@@ -28,32 +26,6 @@ public class TopicService {
 	@Transactional(readOnly = true)
 	public List<Topic> findActive() {
 		return topicRepository.findByActiveTrueOrderByCategoryOrderAscTopicOrderAscIdAsc();
-	}
-
-	@Transactional
-	public Topic create(String title, String englishTitle, String category, int categoryOrder, int topicOrder,
-		List<TopicBadge> badges, boolean active) {
-		Topic topic = new Topic(title, englishTitle, category, categoryOrder, topicOrder, badges, active);
-		return topicRepository.save(topic);
-	}
-
-	@Transactional
-	public Optional<Topic> update(UUID id, String title, String englishTitle, String category, int categoryOrder,
-		int topicOrder, List<TopicBadge> badges, boolean active) {
-		return topicRepository.findById(id)
-			.map(existing -> {
-				existing.update(title, englishTitle, category, categoryOrder, topicOrder, badges, active);
-				return topicRepository.save(existing);
-			});
-	}
-
-	@Transactional
-	public boolean delete(UUID id) {
-		if (!topicRepository.existsById(id)) {
-			return false;
-		}
-		topicRepository.deleteById(id);
-		return true;
 	}
 
 	@Transactional(readOnly = true)

--- a/opicer-api/src/main/java/com/opicer/api/topic/presentation/AdminTopicController.java
+++ b/opicer-api/src/main/java/com/opicer/api/topic/presentation/AdminTopicController.java
@@ -3,7 +3,8 @@ package com.opicer.api.topic.presentation;
 import com.opicer.api.shared.error.ApiException;
 import com.opicer.api.shared.error.ErrorCode;
 import com.opicer.api.shared.presentation.ApiResponse;
-import com.opicer.api.topic.application.TopicService;
+import com.opicer.api.topic.application.TopicCommandService;
+import com.opicer.api.topic.application.TopicQueryService;
 import com.opicer.api.topic.domain.Topic;
 import com.opicer.api.topic.domain.TopicBadge;
 import jakarta.validation.Valid;
@@ -27,15 +28,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/admin/topics")
 public class AdminTopicController {
 
-	private final TopicService topicService;
+	private final TopicQueryService topicQueryService;
+	private final TopicCommandService topicCommandService;
 
-	public AdminTopicController(TopicService topicService) {
-		this.topicService = topicService;
+	public AdminTopicController(TopicQueryService topicQueryService, TopicCommandService topicCommandService) {
+		this.topicQueryService = topicQueryService;
+		this.topicCommandService = topicCommandService;
 	}
 
 	@GetMapping
 	public ResponseEntity<ApiResponse<List<TopicResponse>>> list() {
-		List<TopicResponse> responses = topicService.findAll().stream()
+		List<TopicResponse> responses = topicQueryService.findAll().stream()
 			.map(TopicResponse::from)
 			.toList();
 		return ResponseEntity.ok(ApiResponse.ok("TOPIC_LIST_OK", responses));
@@ -43,7 +46,7 @@ public class AdminTopicController {
 
 	@PostMapping
 	public ResponseEntity<ApiResponse<TopicResponse>> create(@Valid @RequestBody TopicRequest request) {
-		Topic created = topicService.create(
+		Topic created = topicCommandService.create(
 			request.title(),
 			request.englishTitle(),
 			request.category(),
@@ -57,7 +60,7 @@ public class AdminTopicController {
 
 	@PutMapping("/{id}")
 	public ResponseEntity<Object> update(@PathVariable UUID id, @Valid @RequestBody TopicRequest request) {
-		return topicService.update(
+		return topicCommandService.update(
 				id,
 				request.title(),
 				request.englishTitle(),
@@ -74,7 +77,7 @@ public class AdminTopicController {
 
 	@DeleteMapping("/{id}")
 	public ResponseEntity<Object> delete(@PathVariable UUID id) {
-		if (topicService.delete(id)) {
+		if (topicCommandService.delete(id)) {
 			return ResponseEntity.ok(ApiResponse.ok("TOPIC_DELETED", null));
 		}
 		throw new ApiException(ErrorCode.TOPIC_NOT_FOUND, "Topic not found: " + id);

--- a/opicer-api/src/main/java/com/opicer/api/topic/presentation/TopicController.java
+++ b/opicer-api/src/main/java/com/opicer/api/topic/presentation/TopicController.java
@@ -1,7 +1,7 @@
 package com.opicer.api.topic.presentation;
 
 import com.opicer.api.shared.presentation.ApiResponse;
-import com.opicer.api.topic.application.TopicService;
+import com.opicer.api.topic.application.TopicQueryService;
 import com.opicer.api.topic.domain.Topic;
 import com.opicer.api.topic.domain.TopicBadge;
 import java.time.Instant;
@@ -16,15 +16,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/topics")
 public class TopicController {
 
-	private final TopicService topicService;
+	private final TopicQueryService topicQueryService;
 
-	public TopicController(TopicService topicService) {
-		this.topicService = topicService;
+	public TopicController(TopicQueryService topicQueryService) {
+		this.topicQueryService = topicQueryService;
 	}
 
 	@GetMapping
 	public ResponseEntity<ApiResponse<List<TopicResponse>>> list() {
-		List<TopicResponse> responses = topicService.findActive().stream()
+		List<TopicResponse> responses = topicQueryService.findActive().stream()
 			.map(TopicResponse::from)
 			.toList();
 		return ResponseEntity.ok(ApiResponse.ok("TOPIC_LIST_OK", responses));

--- a/opicer-api/src/main/java/com/opicer/api/universalsentence/application/UniversalSentenceCommandService.java
+++ b/opicer-api/src/main/java/com/opicer/api/universalsentence/application/UniversalSentenceCommandService.java
@@ -1,0 +1,46 @@
+package com.opicer.api.universalsentence.application;
+
+import com.opicer.api.universalsentence.domain.UniversalSentence;
+import com.opicer.api.universalsentence.domain.UniversalSentenceType;
+import com.opicer.api.universalsentence.infrastructure.UniversalSentenceRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class UniversalSentenceCommandService {
+
+	private final UniversalSentenceRepository universalSentenceRepository;
+
+	public UniversalSentenceCommandService(UniversalSentenceRepository universalSentenceRepository) {
+		this.universalSentenceRepository = universalSentenceRepository;
+	}
+
+	@Transactional
+	public UniversalSentence create(UniversalSentenceType type, String title, String sentence, List<String> tags,
+		boolean active) {
+		UniversalSentence universalSentence = new UniversalSentence(type, title, sentence, tags, active);
+		return universalSentenceRepository.save(universalSentence);
+	}
+
+	@Transactional
+	public Optional<UniversalSentence> update(UUID id, UniversalSentenceType type, String title, String sentence,
+		List<String> tags, boolean active) {
+		return universalSentenceRepository.findById(id)
+			.map(existing -> {
+				existing.update(type, title, sentence, tags, active);
+				return universalSentenceRepository.save(existing);
+			});
+	}
+
+	@Transactional
+	public boolean delete(UUID id) {
+		if (!universalSentenceRepository.existsById(id)) {
+			return false;
+		}
+		universalSentenceRepository.deleteById(id);
+		return true;
+	}
+}

--- a/opicer-api/src/main/java/com/opicer/api/universalsentence/application/UniversalSentenceQueryService.java
+++ b/opicer-api/src/main/java/com/opicer/api/universalsentence/application/UniversalSentenceQueryService.java
@@ -7,25 +7,24 @@ import com.opicer.api.universalsentence.domain.UniversalSentenceType;
 import com.opicer.api.universalsentence.infrastructure.UniversalSentenceRepository;
 import java.time.Clock;
 import java.time.LocalDate;
-import java.util.Objects;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
-import java.util.Optional;
+import java.util.Objects;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-public class UniversalSentenceService {
+public class UniversalSentenceQueryService {
 
 	private static final int MAX_RANDOM_SIZE = 4;
 
 	private final UniversalSentenceRepository universalSentenceRepository;
 	private final Clock clock;
 
-	public UniversalSentenceService(UniversalSentenceRepository universalSentenceRepository, Clock clock) {
+	public UniversalSentenceQueryService(UniversalSentenceRepository universalSentenceRepository, Clock clock) {
 		this.universalSentenceRepository = universalSentenceRepository;
 		this.clock = clock;
 	}
@@ -33,32 +32,6 @@ public class UniversalSentenceService {
 	@Transactional(readOnly = true)
 	public List<UniversalSentence> findAll() {
 		return universalSentenceRepository.findAll();
-	}
-
-	@Transactional
-	public UniversalSentence create(UniversalSentenceType type, String title, String sentence, List<String> tags,
-		boolean active) {
-		UniversalSentence universalSentence = new UniversalSentence(type, title, sentence, tags, active);
-		return universalSentenceRepository.save(universalSentence);
-	}
-
-	@Transactional
-	public Optional<UniversalSentence> update(UUID id, UniversalSentenceType type, String title, String sentence,
-		List<String> tags, boolean active) {
-		return universalSentenceRepository.findById(id)
-			.map(existing -> {
-				existing.update(type, title, sentence, tags, active);
-				return universalSentenceRepository.save(existing);
-			});
-	}
-
-	@Transactional
-	public boolean delete(UUID id) {
-		if (!universalSentenceRepository.existsById(id)) {
-			return false;
-		}
-		universalSentenceRepository.deleteById(id);
-		return true;
 	}
 
 	@Transactional(readOnly = true)
@@ -103,6 +76,7 @@ public class UniversalSentenceService {
 		return dailySet;
 	}
 
+	@Transactional(readOnly = true)
 	public UniversalSentence getOrThrow(UUID id) {
 		return universalSentenceRepository.findById(id)
 			.orElseThrow(() -> new ApiException(ErrorCode.UNIVERSAL_SENTENCE_NOT_FOUND,

--- a/opicer-api/src/main/java/com/opicer/api/universalsentence/presentation/AdminUniversalSentenceController.java
+++ b/opicer-api/src/main/java/com/opicer/api/universalsentence/presentation/AdminUniversalSentenceController.java
@@ -3,7 +3,8 @@ package com.opicer.api.universalsentence.presentation;
 import com.opicer.api.shared.error.ApiException;
 import com.opicer.api.shared.error.ErrorCode;
 import com.opicer.api.shared.presentation.ApiResponse;
-import com.opicer.api.universalsentence.application.UniversalSentenceService;
+import com.opicer.api.universalsentence.application.UniversalSentenceCommandService;
+import com.opicer.api.universalsentence.application.UniversalSentenceQueryService;
 import com.opicer.api.universalsentence.domain.UniversalSentence;
 import com.opicer.api.universalsentence.domain.UniversalSentenceType;
 import jakarta.validation.Valid;
@@ -27,15 +28,20 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/admin/universal-sentences")
 public class AdminUniversalSentenceController {
 
-	private final UniversalSentenceService universalSentenceService;
+	private final UniversalSentenceQueryService universalSentenceQueryService;
+	private final UniversalSentenceCommandService universalSentenceCommandService;
 
-	public AdminUniversalSentenceController(UniversalSentenceService universalSentenceService) {
-		this.universalSentenceService = universalSentenceService;
+	public AdminUniversalSentenceController(
+		UniversalSentenceQueryService universalSentenceQueryService,
+		UniversalSentenceCommandService universalSentenceCommandService
+	) {
+		this.universalSentenceQueryService = universalSentenceQueryService;
+		this.universalSentenceCommandService = universalSentenceCommandService;
 	}
 
 	@GetMapping
 	public ResponseEntity<ApiResponse<List<UniversalSentenceResponse>>> list() {
-		List<UniversalSentenceResponse> responses = universalSentenceService.findAll().stream()
+		List<UniversalSentenceResponse> responses = universalSentenceQueryService.findAll().stream()
 			.map(UniversalSentenceResponse::from)
 			.toList();
 		return ResponseEntity.ok(ApiResponse.ok("UNIVERSAL_SENTENCE_LIST_OK", responses));
@@ -45,7 +51,7 @@ public class AdminUniversalSentenceController {
 	public ResponseEntity<ApiResponse<UniversalSentenceResponse>> create(
 		@Valid @RequestBody UniversalSentenceRequest request
 	) {
-		UniversalSentence created = universalSentenceService.create(
+		UniversalSentence created = universalSentenceCommandService.create(
 			request.type(),
 			request.title(),
 			request.sentence(),
@@ -58,7 +64,7 @@ public class AdminUniversalSentenceController {
 
 	@PutMapping("/{id}")
 	public ResponseEntity<Object> update(@PathVariable UUID id, @Valid @RequestBody UniversalSentenceRequest request) {
-		return universalSentenceService.update(
+		return universalSentenceCommandService.update(
 				id,
 				request.type(),
 				request.title(),
@@ -74,7 +80,7 @@ public class AdminUniversalSentenceController {
 
 	@DeleteMapping("/{id}")
 	public ResponseEntity<Object> delete(@PathVariable UUID id) {
-		if (universalSentenceService.delete(id)) {
+		if (universalSentenceCommandService.delete(id)) {
 			return ResponseEntity.ok(ApiResponse.ok("UNIVERSAL_SENTENCE_DELETED", null));
 		}
 		throw new ApiException(ErrorCode.UNIVERSAL_SENTENCE_NOT_FOUND,

--- a/opicer-api/src/main/java/com/opicer/api/universalsentence/presentation/UniversalSentenceController.java
+++ b/opicer-api/src/main/java/com/opicer/api/universalsentence/presentation/UniversalSentenceController.java
@@ -1,7 +1,7 @@
 package com.opicer.api.universalsentence.presentation;
 
 import com.opicer.api.shared.presentation.ApiResponse;
-import com.opicer.api.universalsentence.application.UniversalSentenceService;
+import com.opicer.api.universalsentence.application.UniversalSentenceQueryService;
 import com.opicer.api.universalsentence.domain.UniversalSentence;
 import com.opicer.api.universalsentence.domain.UniversalSentenceType;
 import java.time.Instant;
@@ -17,17 +17,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/universal-sentences")
 public class UniversalSentenceController {
 
-	private final UniversalSentenceService universalSentenceService;
+	private final UniversalSentenceQueryService universalSentenceQueryService;
 
-	public UniversalSentenceController(UniversalSentenceService universalSentenceService) {
-		this.universalSentenceService = universalSentenceService;
+	public UniversalSentenceController(UniversalSentenceQueryService universalSentenceQueryService) {
+		this.universalSentenceQueryService = universalSentenceQueryService;
 	}
 
 	@GetMapping("/random")
 	public ResponseEntity<ApiResponse<List<UniversalSentenceResponse>>> random(
 		@RequestParam(defaultValue = "4") int size
 	) {
-		List<UniversalSentenceResponse> responses = universalSentenceService.findRandom(size).stream()
+		List<UniversalSentenceResponse> responses = universalSentenceQueryService.findRandom(size).stream()
 			.map(UniversalSentenceResponse::from)
 			.toList();
 		return ResponseEntity.ok(ApiResponse.ok("UNIVERSAL_SENTENCE_RANDOM_OK", responses));
@@ -35,7 +35,7 @@ public class UniversalSentenceController {
 
 	@GetMapping("/daily")
 	public ResponseEntity<ApiResponse<List<UniversalSentenceResponse>>> daily() {
-		List<UniversalSentenceResponse> responses = universalSentenceService.findDailySet().stream()
+		List<UniversalSentenceResponse> responses = universalSentenceQueryService.findDailySet().stream()
 			.map(UniversalSentenceResponse::from)
 			.toList();
 		return ResponseEntity.ok(ApiResponse.ok("UNIVERSAL_SENTENCE_DAILY_OK", responses));

--- a/opicer-api/src/test/java/com/opicer/api/credit/application/CreditPaymentIdempotencyTest.java
+++ b/opicer-api/src/test/java/com/opicer/api/credit/application/CreditPaymentIdempotencyTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class CreditPaymentIdempotencyTest {
 
 	@Autowired
-	private CreditOrderService creditOrderService;
+	private CreditOrderCommandService creditOrderCommandService;
 
 	@Autowired
 	private CreditPaymentService creditPaymentService;
@@ -32,12 +32,12 @@ class CreditPaymentIdempotencyTest {
 	private CreditPaymentRepository creditPaymentRepository;
 
 	@Autowired
-	private CreditBalanceService creditBalanceService;
+	private CreditBalanceQueryService creditBalanceQueryService;
 
 	@Test
 	void sameKeySamePayloadReturnsExistingPayment() {
 		UUID userId = UUID.randomUUID();
-		CreditOrder order = creditOrderService.createOrder(userId, "PACK_10", 10000);
+		CreditOrder order = creditOrderCommandService.createOrder(userId, "PACK_10", 10000);
 
 		CreditPayment first = creditPaymentService
 			.confirmPaymentWithIdempotency(order.getId(), "TX-IDEMPOTENT-1", "idem-key-1");
@@ -46,13 +46,13 @@ class CreditPaymentIdempotencyTest {
 
 		assertThat(second.getId()).isEqualTo(first.getId());
 		assertThat(creditPaymentRepository.countByOrderId(order.getId())).isEqualTo(1);
-		assertThat(creditBalanceService.getBalance(order.getUserId()).getBalance()).isEqualTo(order.getAmount());
+		assertThat(creditBalanceQueryService.getBalance(order.getUserId()).getBalance()).isEqualTo(order.getAmount());
 	}
 
 	@Test
 	void sameKeyDifferentPayloadThrowsConflict() {
 		UUID userId = UUID.randomUUID();
-		CreditOrder order = creditOrderService.createOrder(userId, "PACK_10", 10000);
+		CreditOrder order = creditOrderCommandService.createOrder(userId, "PACK_10", 10000);
 
 		creditPaymentService.confirmPaymentWithIdempotency(order.getId(), "TX-FIRST", "idem-key-2");
 
@@ -65,7 +65,7 @@ class CreditPaymentIdempotencyTest {
 	@Test
 	void concurrentSameKeyCreatesSinglePaymentAndBalanceUpdate() throws Exception {
 		UUID userId = UUID.randomUUID();
-		CreditOrder order = creditOrderService.createOrder(userId, "PACK_10", 10000);
+		CreditOrder order = creditOrderCommandService.createOrder(userId, "PACK_10", 10000);
 		int threads = 20;
 		ExecutorService executor = Executors.newFixedThreadPool(threads);
 		CountDownLatch startGate = new CountDownLatch(1);
@@ -88,13 +88,13 @@ class CreditPaymentIdempotencyTest {
 		executor.shutdown();
 
 		assertThat(creditPaymentRepository.countByOrderId(order.getId())).isEqualTo(1);
-		assertThat(creditBalanceService.getBalance(order.getUserId()).getBalance()).isEqualTo(order.getAmount());
+		assertThat(creditBalanceQueryService.getBalance(order.getUserId()).getBalance()).isEqualTo(order.getAmount());
 	}
 
 	@Test
 	void concurrentDifferentKeysStillCreateSinglePaymentAndBalanceUpdate() throws Exception {
 		UUID userId = UUID.randomUUID();
-		CreditOrder order = creditOrderService.createOrder(userId, "PACK_10", 10000);
+		CreditOrder order = creditOrderCommandService.createOrder(userId, "PACK_10", 10000);
 		int threads = 20;
 		ExecutorService executor = Executors.newFixedThreadPool(threads);
 		CountDownLatch startGate = new CountDownLatch(1);
@@ -122,6 +122,6 @@ class CreditPaymentIdempotencyTest {
 		executor.shutdown();
 
 		assertThat(creditPaymentRepository.countByOrderId(order.getId())).isEqualTo(1);
-		assertThat(creditBalanceService.getBalance(order.getUserId()).getBalance()).isEqualTo(order.getAmount());
+		assertThat(creditBalanceQueryService.getBalance(order.getUserId()).getBalance()).isEqualTo(order.getAmount());
 	}
 }

--- a/opicer-api/src/test/java/com/opicer/api/credit/application/CreditPaymentRetryTest.java
+++ b/opicer-api/src/test/java/com/opicer/api/credit/application/CreditPaymentRetryTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class CreditPaymentRetryTest {
 
 	@Autowired
-	private CreditOrderService creditOrderService;
+	private CreditOrderCommandService creditOrderCommandService;
 
 	@Autowired
 	private CreditPaymentService creditPaymentService;
@@ -28,12 +28,12 @@ class CreditPaymentRetryTest {
 	private CreditPaymentRepository creditPaymentRepository;
 
 	@Autowired
-	private CreditBalanceService creditBalanceService;
+	private CreditBalanceQueryService creditBalanceQueryService;
 
 	@Test
 	void retryDuringInFlightIsDeduplicatedByDatabaseConstraint() throws Exception {
 		UUID userId = UUID.randomUUID();
-		CreditOrder order = creditOrderService.createOrder(userId, "PACK_10", 10000);
+		CreditOrder order = creditOrderCommandService.createOrder(userId, "PACK_10", 10000);
 
 		ExecutorService executor = Executors.newFixedThreadPool(2);
 		CountDownLatch startGate = new CountDownLatch(1);
@@ -63,7 +63,7 @@ class CreditPaymentRetryTest {
 		executor.shutdown();
 
 		long count = creditPaymentRepository.countByOrderId(order.getId());
-		long balance = creditBalanceService.getBalance(order.getUserId()).getBalance();
+		long balance = creditBalanceQueryService.getBalance(order.getUserId()).getBalance();
 
 		assertThat(count).isEqualTo(1);
 		assertThat(balance).isEqualTo(order.getAmount());

--- a/opicer-api/src/test/java/com/opicer/api/credit/application/CreditPaymentServiceConcurrencyTest.java
+++ b/opicer-api/src/test/java/com/opicer/api/credit/application/CreditPaymentServiceConcurrencyTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class CreditPaymentServiceConcurrencyTest {
 
 	@Autowired
-	private CreditOrderService creditOrderService;
+	private CreditOrderCommandService creditOrderCommandService;
 
 	@Autowired
 	private CreditPaymentService creditPaymentService;
@@ -28,12 +28,12 @@ class CreditPaymentServiceConcurrencyTest {
 	private CreditPaymentRepository creditPaymentRepository;
 
 	@Autowired
-	private com.opicer.api.credit.application.CreditBalanceService creditBalanceService;
+	private CreditBalanceQueryService creditBalanceQueryService;
 
 	@Test
 	void concurrentConfirmIsDeduplicatedByDatabaseConstraint() throws Exception {
 		UUID userId = UUID.randomUUID();
-		CreditOrder order = creditOrderService.createOrder(userId, "PACK_10", 10000);
+		CreditOrder order = creditOrderCommandService.createOrder(userId, "PACK_10", 10000);
 
 		int threads = 10;
 		int requestsPerThread = 10_000;
@@ -64,7 +64,7 @@ class CreditPaymentServiceConcurrencyTest {
 		long count = creditPaymentRepository.countByOrderId(order.getId());
 		assertThat(count).isEqualTo(1);
 
-		long balance = creditBalanceService.getBalance(order.getUserId()).getBalance();
+		long balance = creditBalanceQueryService.getBalance(order.getUserId()).getBalance();
 		assertThat(balance).isEqualTo(order.getAmount());
 	}
 }

--- a/opicer-api/src/test/java/com/opicer/api/goodanswer/presentation/AdminGoodAnswerSampleControllerTest.java
+++ b/opicer-api/src/test/java/com/opicer/api/goodanswer/presentation/AdminGoodAnswerSampleControllerTest.java
@@ -3,7 +3,8 @@ package com.opicer.api.goodanswer.presentation;
 import com.opicer.api.auth.application.JwtService;
 import com.opicer.api.auth.domain.AuthUserPrincipal;
 import com.opicer.api.config.AuthProperties;
-import com.opicer.api.goodanswer.application.GoodAnswerSampleService;
+import com.opicer.api.goodanswer.application.GoodAnswerSampleCommandService;
+import com.opicer.api.goodanswer.application.GoodAnswerSampleQueryService;
 import com.opicer.api.goodanswer.domain.GoodAnswerSample;
 import com.opicer.api.shared.domain.OpicLevel;
 import com.opicer.api.shared.error.ApiException;
@@ -49,7 +50,10 @@ class AdminGoodAnswerSampleControllerTest {
 	private AuthProperties authProperties;
 
 	@MockBean
-	private GoodAnswerSampleService service;
+	private GoodAnswerSampleCommandService commandService;
+
+	@MockBean
+	private GoodAnswerSampleQueryService queryService;
 
 	private Cookie adminCookie;
 	private UUID topicId;
@@ -86,7 +90,7 @@ class AdminGoodAnswerSampleControllerTest {
 		ReflectionTestUtils.setField(sample, "createdAt", java.time.Instant.now());
 		ReflectionTestUtils.setField(sample, "updatedAt", java.time.Instant.now());
 
-		when(service.create(eq(topicId), eq(OpicLevel.IM), anyString(), any(), any(), anyList(), anyList()))
+		when(commandService.create(eq(topicId), eq(OpicLevel.IM), anyString(), any(), any(), anyList(), anyList()))
 			.thenReturn(sample);
 
 		String payload = """
@@ -126,7 +130,7 @@ class AdminGoodAnswerSampleControllerTest {
 		ReflectionTestUtils.setField(sample, "id", UUID.randomUUID());
 		ReflectionTestUtils.setField(sample, "createdAt", java.time.Instant.now());
 		ReflectionTestUtils.setField(sample, "updatedAt", java.time.Instant.now());
-		when(service.listByTopic(topicId)).thenReturn(List.of(sample));
+		when(queryService.listByTopic(topicId)).thenReturn(List.of(sample));
 
 		mockMvc.perform(get("/api/admin/good-answers")
 				.cookie(adminCookie)
@@ -153,7 +157,7 @@ class AdminGoodAnswerSampleControllerTest {
 		ReflectionTestUtils.setField(sample, "createdAt", java.time.Instant.now());
 		ReflectionTestUtils.setField(sample, "updatedAt", java.time.Instant.now());
 
-		when(service.createFromAudio(eq(topicId), eq(OpicLevel.IM), any(), any(), anyList(), anyList()))
+		when(commandService.createFromAudio(eq(topicId), eq(OpicLevel.IM), any(), any(), anyList(), anyList()))
 			.thenReturn(List.of(sample));
 
 		MockMultipartFile file = new MockMultipartFile(
@@ -188,7 +192,7 @@ class AdminGoodAnswerSampleControllerTest {
 
 	@Test
 	void uploadAudio_transcriptionFailed_returns502() throws Exception {
-		when(service.createFromAudio(eq(topicId), eq(OpicLevel.IM), any(), any(), anyList(), anyList()))
+		when(commandService.createFromAudio(eq(topicId), eq(OpicLevel.IM), any(), any(), anyList(), anyList()))
 			.thenThrow(new ApiException(ErrorCode.AI_TRANSCRIPTION_FAILED));
 
 		MockMultipartFile file = new MockMultipartFile(

--- a/opicer-api/src/test/java/com/opicer/api/practice/application/PracticeSessionServiceTest.java
+++ b/opicer-api/src/test/java/com/opicer/api/practice/application/PracticeSessionServiceTest.java
@@ -1,6 +1,7 @@
 package com.opicer.api.practice.application;
 
-import com.opicer.api.credit.application.CreditBalanceService;
+import com.opicer.api.credit.application.CreditBalanceCommandService;
+import com.opicer.api.credit.application.CreditBalanceQueryService;
 import com.opicer.api.practice.domain.TopicSelection;
 import com.opicer.api.practice.infrastructure.PracticeCreditChargeRepository;
 import com.opicer.api.practice.infrastructure.TopicSelectionRepository;
@@ -23,10 +24,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
-class PracticeSessionServiceTest {
+class PracticeSessionCommandServiceTest {
 
 	@Autowired
-	private PracticeSessionService practiceSessionService;
+	private PracticeSessionCommandService practiceSessionCommandService;
 
 	@Autowired
 	private TopicSelectionRepository topicSelectionRepository;
@@ -35,7 +36,10 @@ class PracticeSessionServiceTest {
 	private PracticeCreditChargeRepository practiceCreditChargeRepository;
 
 	@Autowired
-	private CreditBalanceService creditBalanceService;
+	private CreditBalanceCommandService creditBalanceService;
+
+	@Autowired
+	private CreditBalanceQueryService creditBalanceQueryService;
 
 	@BeforeEach
 	void setUp() {
@@ -50,13 +54,13 @@ class PracticeSessionServiceTest {
 		creditBalanceService.addBalance(userId, 10);
 		TopicSelection selection = topicSelectionRepository.save(new TopicSelection(userId, UUID.randomUUID()));
 
-		PracticeSessionService.SubmitResult first = practiceSessionService.submit(userId, selection.getId());
-		PracticeSessionService.SubmitResult second = practiceSessionService.submit(userId, selection.getId());
+		PracticeSessionCommandService.SubmitResult first = practiceSessionCommandService.submit(userId, selection.getId());
+		PracticeSessionCommandService.SubmitResult second = practiceSessionCommandService.submit(userId, selection.getId());
 
 		assertThat(first.alreadyCharged()).isFalse();
 		assertThat(second.alreadyCharged()).isTrue();
 		assertThat(practiceCreditChargeRepository.countByTopicSelectionId(selection.getId())).isEqualTo(1);
-		assertThat(creditBalanceService.getBalance(userId).getBalance()).isEqualTo(8);
+		assertThat(creditBalanceQueryService.getBalance(userId).getBalance()).isEqualTo(8);
 	}
 
 	@Test
@@ -75,7 +79,7 @@ class PracticeSessionServiceTest {
 			futures.add(pool.submit(() -> {
 				ready.countDown();
 				start.await();
-				practiceSessionService.submit(userId, selection.getId());
+				practiceSessionCommandService.submit(userId, selection.getId());
 				return true;
 			}));
 		}
@@ -88,7 +92,7 @@ class PracticeSessionServiceTest {
 		pool.shutdown();
 
 		assertThat(practiceCreditChargeRepository.countByTopicSelectionId(selection.getId())).isEqualTo(1);
-		assertThat(creditBalanceService.getBalance(userId).getBalance()).isEqualTo(8);
+		assertThat(creditBalanceQueryService.getBalance(userId).getBalance()).isEqualTo(8);
 	}
 
 	@Test
@@ -110,7 +114,7 @@ class PracticeSessionServiceTest {
 			futures.add(pool.submit(() -> {
 				ready.countDown();
 				start.await();
-				practiceSessionService.submit(userId, selection.getId());
+				practiceSessionCommandService.submit(userId, selection.getId());
 				successCount.incrementAndGet();
 				return true;
 			}));
@@ -125,7 +129,7 @@ class PracticeSessionServiceTest {
 
 		assertThat(successCount.get()).isEqualTo(totalRequests);
 		assertThat(practiceCreditChargeRepository.countByTopicSelectionId(selection.getId())).isEqualTo(1);
-		assertThat(creditBalanceService.getBalance(userId).getBalance()).isEqualTo(98);
+		assertThat(creditBalanceQueryService.getBalance(userId).getBalance()).isEqualTo(98);
 	}
 
 	@Test
@@ -157,7 +161,7 @@ class PracticeSessionServiceTest {
 
 		assertThat(success).isEqualTo(1);
 		assertThat(failed).isEqualTo(1);
-		assertThat(creditBalanceService.getBalance(userId).getBalance()).isZero();
+		assertThat(creditBalanceQueryService.getBalance(userId).getBalance()).isZero();
 		assertThat(practiceCreditChargeRepository.count()).isEqualTo(1);
 	}
 
@@ -171,7 +175,7 @@ class PracticeSessionServiceTest {
 		creditBalanceService.addBalance(attacker, 10);
 		TopicSelection selection = topicSelectionRepository.save(new TopicSelection(owner, UUID.randomUUID()));
 
-		assertThatThrownBy(() -> practiceSessionService.submit(attacker, selection.getId()))
+		assertThatThrownBy(() -> practiceSessionCommandService.submit(attacker, selection.getId()))
 			.isInstanceOf(ApiException.class)
 			.hasMessageContaining("Topic selection not found");
 	}
@@ -183,11 +187,11 @@ class PracticeSessionServiceTest {
 		creditBalanceService.addBalance(userId, 1);
 		TopicSelection selection = topicSelectionRepository.save(new TopicSelection(userId, UUID.randomUUID()));
 
-		assertThatThrownBy(() -> practiceSessionService.submit(userId, selection.getId()))
+		assertThatThrownBy(() -> practiceSessionCommandService.submit(userId, selection.getId()))
 			.isInstanceOf(ApiException.class)
 			.hasMessageContaining("At least 2 credits");
 		assertThat(practiceCreditChargeRepository.countByTopicSelectionId(selection.getId())).isZero();
-		assertThat(creditBalanceService.getBalance(userId).getBalance()).isEqualTo(1);
+		assertThat(creditBalanceQueryService.getBalance(userId).getBalance()).isEqualTo(1);
 	}
 
 	private Callable<Boolean> callSubmit(
@@ -200,7 +204,7 @@ class PracticeSessionServiceTest {
 			ready.countDown();
 			start.await();
 			try {
-				practiceSessionService.submit(userId, selectionId);
+				practiceSessionCommandService.submit(userId, selectionId);
 				return true;
 			} catch (ApiException ex) {
 				return false;

--- a/opicer-api/src/test/java/com/opicer/api/practice/presentation/PracticeSessionControllerTest.java
+++ b/opicer-api/src/test/java/com/opicer/api/practice/presentation/PracticeSessionControllerTest.java
@@ -3,7 +3,7 @@ package com.opicer.api.practice.presentation;
 import com.opicer.api.auth.application.JwtService;
 import com.opicer.api.auth.domain.AuthUserPrincipal;
 import com.opicer.api.config.AuthProperties;
-import com.opicer.api.practice.application.PracticeSessionService;
+import com.opicer.api.practice.application.PracticeSessionCommandService;
 import com.opicer.api.shared.error.ApiException;
 import com.opicer.api.shared.error.ErrorCode;
 import com.opicer.api.user.domain.AuthProvider;
@@ -39,7 +39,7 @@ class PracticeSessionControllerTest {
 	private AuthProperties authProperties;
 
 	@MockBean
-	private PracticeSessionService practiceSessionService;
+	private PracticeSessionCommandService practiceSessionCommandService;
 
 	private Cookie userCookie;
 
@@ -58,12 +58,12 @@ class PracticeSessionControllerTest {
 
 	@Test
 	void submitSuccessReturns200() throws Exception {
-		PracticeSessionService.SubmitResult result = new PracticeSessionService.SubmitResult(
+		PracticeSessionCommandService.SubmitResult result = new PracticeSessionCommandService.SubmitResult(
 			UUID.randomUUID(),
 			false,
 			2
 		);
-		when(practiceSessionService.submit(any(), any())).thenReturn(result);
+		when(practiceSessionCommandService.submit(any(), any())).thenReturn(result);
 
 		mockMvc.perform(post("/api/practice/sessions/submit")
 				.cookie(userCookie)
@@ -79,7 +79,7 @@ class PracticeSessionControllerTest {
 
 	@Test
 	void submitInsufficientBalanceReturns402() throws Exception {
-		when(practiceSessionService.submit(any(), any()))
+		when(practiceSessionCommandService.submit(any(), any()))
 			.thenThrow(new ApiException(ErrorCode.CREDIT_INSUFFICIENT_BALANCE));
 
 		mockMvc.perform(post("/api/practice/sessions/submit")

--- a/opicer-api/src/test/java/com/opicer/api/universalsentence/application/UniversalSentenceServiceTest.java
+++ b/opicer-api/src/test/java/com/opicer/api/universalsentence/application/UniversalSentenceServiceTest.java
@@ -20,17 +20,17 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class UniversalSentenceServiceTest {
+class UniversalSentenceQueryServiceTest {
 
 	@Mock
 	private UniversalSentenceRepository repository;
 
-	private UniversalSentenceService service;
+	private UniversalSentenceQueryService service;
 
 	@BeforeEach
 	void setUp() {
 		Clock fixedClock = Clock.fixed(Instant.parse("1970-01-02T00:00:00Z"), ZoneOffset.UTC);
-		service = new UniversalSentenceService(repository, fixedClock);
+		service = new UniversalSentenceQueryService(repository, fixedClock);
 	}
 
 	@Test


### PR DESCRIPTION
Closes #73

## Summary
- Applied Light CQRS to backend service layer by splitting mixed services into Command/Query services.
- Updated controllers to depend on command/query services by endpoint intent.
- Updated affected tests to new service names/wiring.

## Main changes
- credit: `CreditBalanceCommandService`/`CreditBalanceQueryService`, `CreditOrderCommandService`/`CreditOrderQueryService`
- practice: `TopicSelectionCommandService`, `PracticeSessionCommandService`
- topic: `TopicCommandService`/`TopicQueryService`
- question: `QuestionCommandService`/`QuestionQueryService`
- daily sentence: `DailySentenceCommandService`/`DailySentenceQueryService`
- universal sentence: `UniversalSentenceCommandService`/`UniversalSentenceQueryService`
- prompt: `PromptVersionCommandService`/`PromptVersionQueryService`
- good answer: `GoodAnswerSampleCommandService`/`GoodAnswerSampleQueryService`
- `PracticeAiService` now uses query services for prompt/sample reads

## Notes
- API contract/route shape is unchanged (internal service dependency refactor).
- Existing untracked local docs (`docs/tdd/logout.md`, `plan-logout.md`) were not included.